### PR TITLE
記事ページSEO対応

### DIFF
--- a/prisma/migrations/20260212000000_add_is_searchable_to_workspace/migration.sql
+++ b/prisma/migrations/20260212000000_add_is_searchable_to_workspace/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN "isSearchable" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -389,6 +389,9 @@ model Workspace {
   // ストーリー（1対1）
   story     Story?
 
+  // 検索エンジンへの公開設定（trueの場合、サイトマップに含まれ、検索エンジンにインデックスされる）
+  isSearchable Boolean @default(false)
+
   // 作成・更新日時
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/src/app/_components/curators-writing-workspace/index.tsx
+++ b/src/app/_components/curators-writing-workspace/index.tsx
@@ -1066,6 +1066,7 @@ const CuratorsWritingWorkspace = ({
         workspaceId={workspace.id}
         workspaceStatus={workspace.status}
         workspaceName={workspace.name}
+        isSearchable={workspace.isSearchable}
         hasStories={
           (metaGraphStory.metaGraphData?.narrativeFlow?.length ?? 0) > 0
         }

--- a/src/app/_components/curators-writing-workspace/publish-workspace-modal.tsx
+++ b/src/app/_components/curators-writing-workspace/publish-workspace-modal.tsx
@@ -21,12 +21,50 @@ const PrintOutputButton: React.FC<{ workspaceId: string }> = ({
   </LinkButton>
 );
 
+/** 検索エンジン公開設定のトグルコンポーネント */
+const SearchableToggle: React.FC<{
+  isSearchable: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}> = ({ isSearchable, onChange, disabled = false }) => (
+  <div className="flex flex-col gap-2 rounded-md border border-slate-600 p-3">
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium text-slate-200">
+          検索エンジンに公開
+        </span>
+        <span className="text-xs text-slate-400">
+          有効にすると、GoogleなどのWeb検索結果に表示されるようになります
+        </span>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isSearchable}
+        disabled={disabled}
+        onClick={() => onChange(!isSearchable)}
+        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-slate-800 ${
+          disabled ? "cursor-not-allowed opacity-50" : ""
+        } ${isSearchable ? "bg-blue-600" : "bg-slate-600"}`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+            isSearchable ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  </div>
+);
+
 interface PublishWorkspaceModalProps {
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   workspaceId: string;
   workspaceStatus: WorkspaceStatus;
   workspaceName: string;
+  /** 現在の isSearchable 値（公開済みの場合のみ） */
+  isSearchable?: boolean;
   /** ストーリーが生成されている場合のみ出力ボタンを表示する */
   hasStories?: boolean;
   onSuccess?: () => void;
@@ -38,6 +76,7 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
   workspaceId,
   workspaceStatus,
   workspaceName,
+  isSearchable: initialIsSearchable = false,
   hasStories = false,
   onSuccess,
 }) => {
@@ -45,6 +84,12 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
   const [publishedWorkspaceId, setPublishedWorkspaceId] = useState<
     string | null
   >(null);
+  const [isSearchable, setIsSearchable] = useState(initialIsSearchable);
+
+  // 初期値が変わったら反映
+  useEffect(() => {
+    setIsSearchable(initialIsSearchable);
+  }, [initialIsSearchable]);
 
   const handleClose = () => {
     setIsOpen(false);
@@ -80,8 +125,19 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
     },
   });
 
+  const updateSearchable = api.workspace.updateSearchable.useMutation({
+    onSuccess: () => {
+      if (onSuccess) {
+        onSuccess();
+      }
+    },
+    onError: (error) => {
+      console.error("検索設定更新エラー:", error);
+    },
+  });
+
   const handlePublish = () => {
-    publishWorkspace.mutate({ workspaceId });
+    publishWorkspace.mutate({ workspaceId, isSearchable });
   };
 
   const handleUnpublish = () => {
@@ -89,6 +145,14 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
       id: workspaceId,
       status: "DRAFT",
     });
+  };
+
+  const handleSearchableChange = (value: boolean) => {
+    setIsSearchable(value);
+    // 既に公開済みの場合はすぐにAPIで保存
+    if (workspaceStatus === WorkspaceStatus.PUBLISHED) {
+      updateSearchable.mutate({ workspaceId, isSearchable: value });
+    }
   };
 
   // モーダルが開かれたときに既に公開済みかどうかを確認
@@ -123,6 +187,24 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
                 {workspaceName}
               </Link>
             </div>
+
+            <SearchableToggle
+              isSearchable={isSearchable}
+              onChange={handleSearchableChange}
+              disabled={updateSearchable.isPending}
+            />
+
+            {updateSearchable.isSuccess && (
+              <div className="rounded-md bg-green-900/50 p-2 text-xs text-green-200">
+                検索エンジン公開設定を更新しました
+              </div>
+            )}
+
+            {updateSearchable.isError && (
+              <div className="rounded-md bg-red-900/50 p-2 text-xs text-red-200">
+                設定の更新に失敗しました: {updateSearchable.error?.message ?? "不明なエラー"}
+              </div>
+            )}
 
             {unpublishWorkspace.isError && (
               <div className="rounded-md bg-red-900/50 p-3 text-sm text-red-200">
@@ -176,6 +258,11 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
               記事を公開しますか？公開後は一般公開され、誰でも閲覧できるようになります。
             </div>
 
+            <SearchableToggle
+              isSearchable={isSearchable}
+              onChange={setIsSearchable}
+            />
+
             {publishWorkspace.isError && (
               <div className="rounded-md bg-red-900/50 p-3 text-sm text-red-200">
                 <p>
@@ -215,6 +302,12 @@ export const PublishWorkspaceModal: React.FC<PublishWorkspaceModalProps> = ({
               <div className="rounded-md bg-green-900/50 p-3 text-sm text-green-200">
                 <p>記事が公開されました！</p>
               </div>
+
+              {isSearchable && (
+                <div className="rounded-md bg-blue-900/50 p-2 text-xs text-blue-200">
+                  検索エンジンへの公開が有効です。しばらくするとWeb検索結果に表示されるようになります。
+                </div>
+              )}
 
               <div className="flex flex-col gap-2">
                 <Link

--- a/src/app/_utils/text/extract-text-from-tiptap.ts
+++ b/src/app/_utils/text/extract-text-from-tiptap.ts
@@ -1,0 +1,31 @@
+/**
+ * TipTap JSON コンテンツからプレーンテキストを抽出する
+ * メタデータ（description等）生成用
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function extractTextFromTiptap(node: any, maxLength = 200): string {
+  if (!node) return "";
+
+  const parts: string[] = [];
+
+  function walk(n: unknown): void {
+    if (!n || typeof n !== "object") return;
+    const obj = n as Record<string, unknown>;
+
+    if (obj.type === "text" && typeof obj.text === "string") {
+      parts.push(obj.text);
+    }
+
+    if (Array.isArray(obj.content)) {
+      for (const child of obj.content) {
+        walk(child);
+      }
+    }
+  }
+
+  walk(node);
+
+  const fullText = parts.join(" ").replace(/\s+/g, " ").trim();
+  if (fullText.length <= maxLength) return fullText;
+  return fullText.slice(0, maxLength) + "…";
+}

--- a/src/app/articles/[workspaceId]/article-page-client.tsx
+++ b/src/app/articles/[workspaceId]/article-page-client.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useParams, useSearchParams } from "next/navigation";
+import { api } from "@/trpc/react";
+import { PublicArticleViewer } from "@/app/_components/article/public-article-viewer";
+import { ScrollStorytellingViewer } from "@/app/_components/article/scroll-storytelling-viewer";
+import { ScrollStorytellingViewerUnified } from "@/app/_components/article/scroll-storytelling-viewer-unified";
+import type { JSONContent } from "@tiptap/react";
+import { ArticleFooter } from "@/app/_components/article/article-footer";
+import { ProfileCard } from "@/app/_components/article/profile-card";
+
+export default function ArticlePageClient() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const workspaceId = params.workspaceId as string;
+  /** デフォルトは unified。?graph=legacy で従来のグラフビューを表示 */
+  const useUnifiedGraph = searchParams.get("graph") !== "legacy";
+
+  const {
+    data: workspaceData,
+    isLoading,
+    error,
+  } = api.workspace.getPublishedWithStory.useQuery(
+    { id: workspaceId },
+    {
+      enabled: !!workspaceId,
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <div className="flex flex-col items-center text-center text-white">
+          <div className="mb-4 h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600"></div>
+          <div>記事を読み込み中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <div className="text-center text-white">
+          <h1 className="mb-4 text-2xl font-bold">エラー</h1>
+          <p className="text-red-400">{error.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!workspaceData) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <div className="text-center text-white">
+          <h1 className="mb-4 text-2xl font-bold">記事が見つかりません</h1>
+          <p className="text-gray-400">
+            指定された記事は存在しないか、公開されていません
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const content = (workspaceData.content as JSONContent) ?? {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "",
+          },
+        ],
+      },
+    ],
+  };
+
+  const topicSpaceId = workspaceData.referencedTopicSpaces[0]?.id ?? "";
+  const metaGraphData = workspaceData.metaGraphData ?? null;
+  const useScrollStorytelling =
+    metaGraphData != null &&
+    Array.isArray(metaGraphData.narrativeFlow) &&
+    metaGraphData.narrativeFlow.length > 0;
+
+  if (!topicSpaceId && !useScrollStorytelling) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <div className="text-center text-white">
+          <h1 className="mb-4 text-2xl font-bold">エラー</h1>
+          <p className="text-gray-400">
+            この記事には参照されているリポジトリがありません
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <main className="z-0 flex min-h-screen flex-col items-center justify-center bg-slate-900 pb-16 xl:pb-0">
+      <div className="flex w-full flex-col items-center justify-center pt-12">
+        <div className="flex flex-col gap-1 xl:flex-row">
+
+          {useScrollStorytelling && metaGraphData ? (
+            useUnifiedGraph ? (
+              <ScrollStorytellingViewerUnified
+                graphDocument={workspaceData.graphDocument}
+                metaGraphData={metaGraphData}
+                workspaceTitle={workspaceData.name}
+              />
+            ) : (
+              <ScrollStorytellingViewer
+                graphDocument={workspaceData.graphDocument}
+                metaGraphData={metaGraphData}
+              />
+            )
+          ) : (
+            <PublicArticleViewer
+              content={content}
+              graphDocument={workspaceData.graphDocument}
+              topicSpaceId={topicSpaceId}
+              workspaceName={workspaceData.name}
+              userName={workspaceData.user.name ?? ""}
+              userImage={workspaceData.user.image ?? ""}
+            />
+          )}
+          <div className="flex w-full flex-col gap-1 p-4 xl:hidden">
+            <ProfileCard userId={workspaceData.userId} />
+          </div>
+        </div>
+
+        <div className="w-full text-white">
+          <ArticleFooter />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "https://arstraverse.com";
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/articles/", "/about"],
+        disallow: [
+          "/api/",
+          "/dashboard",
+          "/workspaces",
+          "/topic-spaces",
+          "/documents",
+          "/account",
+          "/annotations",
+          "/proposals",
+          "/graph",
+        ],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,49 @@
+import type { MetadataRoute } from "next";
+import { db } from "@/server/db";
+import { WorkspaceStatus } from "@prisma/client";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "https://arstraverse.com";
+
+  // 公開済みの全ワークスペース（記事）を取得
+  const publishedWorkspaces = await db.workspace.findMany({
+    where: {
+      status: WorkspaceStatus.PUBLISHED,
+      isDeleted: false,
+    },
+    select: {
+      id: true,
+      updatedAt: true,
+    },
+    orderBy: {
+      updatedAt: "desc",
+    },
+  });
+
+  const articleEntries: MetadataRoute.Sitemap = publishedWorkspaces.map(
+    (workspace) => ({
+      url: `${baseUrl}/articles/${workspace.id}`,
+      lastModified: workspace.updatedAt,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    }),
+  );
+
+  // 静的ページ
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+  ];
+
+  return [...staticEntries, ...articleEntries];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,11 +5,12 @@ import { WorkspaceStatus } from "@prisma/client";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "https://arstraverse.com";
 
-  // 公開済みの全ワークスペース（記事）を取得
+  // 公開済みかつ検索エンジン公開が有効なワークスペース（記事）のみ取得
   const publishedWorkspaces = await db.workspace.findMany({
     where: {
       status: WorkspaceStatus.PUBLISHED,
       isDeleted: false,
+      isSearchable: true,
     },
     select: {
       id: true,


### PR DESCRIPTION
Implement comprehensive SEO for article pages to make them discoverable by search engines.

Previously, article pages were fully client-side rendered, making their content invisible to search engine crawlers. This PR converts the article pages to server components, adds dynamic metadata (title, description, OGP), structured data (JSON-LD), a `robots.txt` file, and a dynamic `sitemap.xml` to ensure content is indexed and displayed correctly in search results.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-baada546-3c24-400c-84a2-815fbffb5be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-baada546-3c24-400c-84a2-815fbffb5be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

