### PR TITLE
feat(graph): enhance edge rendering with node pair transformations

### DIFF
--- a/e2e/kg/edge-cdt-node-pair-animation.unit.spec.ts
+++ b/e2e/kg/edge-cdt-node-pair-animation.unit.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+import {
+  CDT_CATEGORIES,
+} from "@/app/const/edge-cdt-animation";
+import {
+  CDT_NODE_PAIR_MAP,
+  NODE_PAIR_MOTION_MODES,
+  computeNodePairOffset,
+  getNodePairDurationMs,
+  type NodePairMotionSpec,
+} from "@/app/const/edge-cdt-node-pair-animation";
+
+const UNIT_VEC_RIGHT = { ux: 1, uy: 0 };
+const UNIT_VEC_DIAG = { ux: Math.SQRT1_2, uy: Math.SQRT1_2 };
+
+test.describe("edge-cdt-node-pair-animation", () => {
+  test("CDT_NODE_PAIR_MAP は8カテゴリすべてにエントリがある", () => {
+    for (const category of CDT_CATEGORIES) {
+      const spec = CDT_NODE_PAIR_MAP[category];
+      expect(spec).toBeDefined();
+      expect(NODE_PAIR_MOTION_MODES).toContain(spec.mode);
+      expect(spec.amplitudePx).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("getNodePairDurationMs は正の値を返す", () => {
+    for (const category of CDT_CATEGORIES) {
+      expect(getNodePairDurationMs(category)).toBeGreaterThan(0);
+    }
+  });
+
+  test("t=0 のとき全モードで dx=0, dy=0 (sin(0)=0 ベース)", () => {
+    for (const category of CDT_CATEGORIES) {
+      const spec = CDT_NODE_PAIR_MAP[category];
+      const src = computeNodePairOffset(spec, "source", 0, UNIT_VEC_RIGHT);
+      expect(src.dx).toBeCloseTo(0, 5);
+      expect(src.dy).toBeCloseTo(0, 5);
+      const tgt = computeNodePairOffset(spec, "target", 0, UNIT_VEC_RIGHT);
+      expect(tgt.dx).toBeCloseTo(0, 5);
+      expect(tgt.dy).toBeCloseTo(0, 5);
+    }
+  });
+
+  test("scale は常に正値", () => {
+    for (const category of CDT_CATEGORIES) {
+      const spec = CDT_NODE_PAIR_MAP[category];
+      for (let i = 0; i <= 10; i++) {
+        const t = i / 10;
+        const src = computeNodePairOffset(spec, "source", t, UNIT_VEC_RIGHT);
+        const tgt = computeNodePairOffset(spec, "target", t, UNIT_VEC_RIGHT);
+        expect(src.scale).toBeGreaterThan(0);
+        expect(tgt.scale).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("PTRANS (slideAlong, driveSourceOnly) は target が静止", () => {
+    const spec = CDT_NODE_PAIR_MAP.PTRANS;
+    expect(spec.driveSourceOnly).toBe(true);
+    for (let i = 0; i <= 10; i++) {
+      const t = i / 10;
+      const tgt = computeNodePairOffset(spec, "target", t, UNIT_VEC_RIGHT);
+      expect(tgt.dx).toBe(0);
+      expect(tgt.dy).toBe(0);
+      expect(tgt.scale).toBe(1);
+    }
+  });
+
+  test("PROPEL (repel) の source と target は逆方向に変位する", () => {
+    const spec = CDT_NODE_PAIR_MAP.PROPEL;
+    const t = 0.25; // sin(pi/2) = 1 → peak
+    const src = computeNodePairOffset(spec, "source", t, UNIT_VEC_RIGHT);
+    const tgt = computeNodePairOffset(spec, "target", t, UNIT_VEC_RIGHT);
+    // source は正方向（sign=-1 * -sign → 正）、target は負方向に弾く
+    expect(src.dx * tgt.dx).toBeLessThanOrEqual(0);
+  });
+
+  test("SPEAK (scalePulse) は位置変化なし", () => {
+    const spec = CDT_NODE_PAIR_MAP.SPEAK;
+    for (let i = 0; i <= 10; i++) {
+      const t = i / 10;
+      const src = computeNodePairOffset(spec, "source", t, UNIT_VEC_DIAG);
+      expect(src.dx).toBe(0);
+      expect(src.dy).toBe(0);
+      expect(src.scale).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test("attract 系は source・target が互いに接近する方向に変位", () => {
+    for (const category of ["ATRANS", "INGEST"] as const) {
+      const spec = CDT_NODE_PAIR_MAP[category];
+      const t = 0.5; // (1-cos(pi))/2 = 1 → peak
+      const src = computeNodePairOffset(spec, "source", t, UNIT_VEC_RIGHT);
+      const tgt = computeNodePairOffset(spec, "target", t, UNIT_VEC_RIGHT);
+      // source moves in +x (toward target), target in -x (toward source)
+      expect(src.dx).toBeGreaterThan(0);
+      expect(tgt.dx).toBeLessThan(0);
+    }
+  });
+
+  test("amplitudePx=0 のモードは常に dx=dy=0", () => {
+    const zeroAmpSpec: NodePairMotionSpec = { mode: "scalePulse", amplitudePx: 0 };
+    for (let i = 0; i <= 10; i++) {
+      const t = i / 10;
+      const r = computeNodePairOffset(zeroAmpSpec, "source", t, UNIT_VEC_RIGHT);
+      expect(r.dx).toBe(0);
+      expect(r.dy).toBe(0);
+    }
+  });
+
+  test("斜め方向の edgeVec でもオフセットが計算される", () => {
+    const spec = CDT_NODE_PAIR_MAP.PTRANS;
+    const src = computeNodePairOffset(spec, "source", 0.25, UNIT_VEC_DIAG);
+    expect(Math.abs(src.dx)).toBeGreaterThan(0);
+    expect(Math.abs(src.dy)).toBeGreaterThan(0);
+    expect(Math.abs(src.dx - src.dy)).toBeLessThan(0.001);
+  });
+});

--- a/e2e/kg/edge-cdt-node-pair-animation.unit.spec.ts
+++ b/e2e/kg/edge-cdt-node-pair-animation.unit.spec.ts
@@ -7,6 +7,8 @@ import {
   NODE_PAIR_MOTION_MODES,
   computeNodePairOffset,
   getNodePairDurationMs,
+  layoutPosWithNodePair,
+  nodePairOffsetLayoutScale,
   type NodePairMotionSpec,
 } from "@/app/const/edge-cdt-node-pair-animation";
 
@@ -106,6 +108,17 @@ test.describe("edge-cdt-node-pair-animation", () => {
       expect(r.dx).toBe(0);
       expect(r.dy).toBe(0);
     }
+  });
+
+  test("nodePairOffsetLayoutScale は zoom の逆数を返す", () => {
+    expect(nodePairOffsetLayoutScale(2)).toBe(0.5);
+    expect(nodePairOffsetLayoutScale(0)).toBe(1);
+  });
+
+  test("layoutPosWithNodePair は viewScale でオフセットをレイアウト座標に換算する", () => {
+    const pos = layoutPosWithNodePair(10, 20, { dx: 8, dy: 0, scale: 1 }, 0.5);
+    expect(pos.x).toBe(14);
+    expect(pos.y).toBe(20);
   });
 
   test("斜め方向の edgeVec でもオフセットが計算される", () => {

--- a/src/app/_components/d3/force/graph-link-edge-semantic-pictogram.tsx
+++ b/src/app/_components/d3/force/graph-link-edge-semantic-pictogram.tsx
@@ -4,6 +4,7 @@ import type { CustomLinkType, CustomNodeType } from "@/app/const/types";
 import type { EdgeMotionConfig } from "@/app/const/edge-cdt-animation";
 import {
   layoutPosWithNodePair,
+  nodePairOffsetLayoutScale,
   type NodePairTransform,
 } from "@/app/const/edge-cdt-node-pair-animation";
 import { EdgeSemanticPictogram } from "./storytelling-graph/components/edge-semantic-pictogram";
@@ -30,15 +31,18 @@ export function GraphLinkEdgeSemanticPictogram({
 
   const modSource = graphLink.source as CustomNodeType;
   const modTarget = graphLink.target as CustomNodeType;
+  const pairLayoutScale = nodePairOffsetLayoutScale(displayScale);
   const src = layoutPosWithNodePair(
     modSource.x ?? 0,
     modSource.y ?? 0,
     getNodePairTransform?.(modSource.id) ?? null,
+    pairLayoutScale,
   );
   const tgt = layoutPosWithNodePair(
     modTarget.x ?? 0,
     modTarget.y ?? 0,
     getNodePairTransform?.(modTarget.id) ?? null,
+    pairLayoutScale,
   );
   const midX = (src.x + tgt.x) / 2;
   const midY = (src.y + tgt.y) / 2;

--- a/src/app/_components/d3/force/graph-link-edge-semantic-pictogram.tsx
+++ b/src/app/_components/d3/force/graph-link-edge-semantic-pictogram.tsx
@@ -2,12 +2,17 @@
 
 import type { CustomLinkType, CustomNodeType } from "@/app/const/types";
 import type { EdgeMotionConfig } from "@/app/const/edge-cdt-animation";
+import {
+  layoutPosWithNodePair,
+  type NodePairTransform,
+} from "@/app/const/edge-cdt-node-pair-animation";
 import { EdgeSemanticPictogram } from "./storytelling-graph/components/edge-semantic-pictogram";
 
 export type GraphLinkEdgeSemanticPictogramProps = {
   graphLink: CustomLinkType;
   getEdgeMotionConfig: (edgeId: string) => EdgeMotionConfig | null;
   displayScale: number;
+  getNodePairTransform?: (nodeId: string) => NodePairTransform | null;
 };
 
 /**
@@ -18,14 +23,25 @@ export function GraphLinkEdgeSemanticPictogram({
   graphLink,
   getEdgeMotionConfig,
   displayScale,
+  getNodePairTransform,
 }: GraphLinkEdgeSemanticPictogramProps) {
   const motionConfig = getEdgeMotionConfig(graphLink.id);
   if (!motionConfig) return null;
 
   const modSource = graphLink.source as CustomNodeType;
   const modTarget = graphLink.target as CustomNodeType;
-  const midX = ((modSource.x ?? 0) + (modTarget.x ?? 0)) / 2;
-  const midY = ((modSource.y ?? 0) + (modTarget.y ?? 0)) / 2;
+  const src = layoutPosWithNodePair(
+    modSource.x ?? 0,
+    modSource.y ?? 0,
+    getNodePairTransform?.(modSource.id) ?? null,
+  );
+  const tgt = layoutPosWithNodePair(
+    modTarget.x ?? 0,
+    modTarget.y ?? 0,
+    getNodePairTransform?.(modTarget.id) ?? null,
+  );
+  const midX = (src.x + tgt.x) / 2;
+  const midY = (src.y + tgt.y) / 2;
 
   return (
     <EdgeSemanticPictogram

--- a/src/app/_components/d3/force/graph.tsx
+++ b/src/app/_components/d3/force/graph.tsx
@@ -30,7 +30,10 @@ import {
 } from "./storytelling-graph/components/cdt-animated-edge-path";
 import { GraphLinkEdgeSemanticPictogram } from "./graph-link-edge-semantic-pictogram";
 import { useNodePairSemanticMotion } from "./storytelling-graph/hooks/use-node-pair-semantic-motion";
-import { layoutPosWithNodePair } from "@/app/const/edge-cdt-node-pair-animation";
+import {
+  layoutPosWithNodePair,
+  nodePairOffsetLayoutScale,
+} from "@/app/const/edge-cdt-node-pair-animation";
 import type { NodePairTransform } from "@/app/const/edge-cdt-node-pair-animation";
 
 /** 同一ノード対のエッジをグループ化するキー（ソース・ターゲットの順序を正規化） */
@@ -157,12 +160,14 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
         ? 2.5
         : 0;
 
+  const pairLayoutScale = nodePairOffsetLayoutScale(currentScale);
+
   return (
     <g
       key={graphNode.id}
       ref={nodeRef}
       className={`${graphIdentifier}-node cursor-pointer`}
-      transform={`translate(${(graphNode.x ?? 0) + (pairTransform?.dx ?? 0)}, ${(graphNode.y ?? 0) + (pairTransform?.dy ?? 0)})`}
+      transform={`translate(${(graphNode.x ?? 0) + (pairTransform?.dx ?? 0) * pairLayoutScale}, ${(graphNode.y ?? 0) + (pairTransform?.dy ?? 0) * pairLayoutScale})`}
       onClick={() => {
         if (isSelectionMode) {
           onNodeSelectionToggle?.(graphNode);
@@ -925,15 +930,18 @@ export const D3ForceGraph = ({
                   const tgtPair = showEdgeSemanticAnimation
                     ? getNodePairTransform(modTarget.id)
                     : null;
+                  const pairLayoutScale = nodePairOffsetLayoutScale(currentScale);
                   const srcPos = layoutPosWithNodePair(
                     modSource.x ?? 0,
                     modSource.y ?? 0,
                     srcPair,
+                    pairLayoutScale,
                   );
                   const tgtPos = layoutPosWithNodePair(
                     modTarget.x ?? 0,
                     modTarget.y ?? 0,
                     tgtPair,
+                    pairLayoutScale,
                   );
 
                   return (
@@ -1093,15 +1101,18 @@ export const D3ForceGraph = ({
                     const tgtPair = showEdgeSemanticAnimation
                       ? getNodePairTransform(modTarget.id)
                       : null;
+                    const pairLayoutScale = nodePairOffsetLayoutScale(currentScale);
                     const srcPos = layoutPosWithNodePair(
                       modSource.x ?? 0,
                       modSource.y ?? 0,
                       srcPair,
+                      pairLayoutScale,
                     );
                     const tgtPos = layoutPosWithNodePair(
                       modTarget.x ?? 0,
                       modTarget.y ?? 0,
                       tgtPair,
+                      pairLayoutScale,
                     );
                     const labelX = (srcPos.x + tgtPos.x) / 2;
                     const labelY = (srcPos.y + tgtPos.y) / 2;

--- a/src/app/_components/d3/force/graph.tsx
+++ b/src/app/_components/d3/force/graph.tsx
@@ -29,6 +29,9 @@ import {
   CdtEdgeGlowFilterDef,
 } from "./storytelling-graph/components/cdt-animated-edge-path";
 import { GraphLinkEdgeSemanticPictogram } from "./graph-link-edge-semantic-pictogram";
+import { useNodePairSemanticMotion } from "./storytelling-graph/hooks/use-node-pair-semantic-motion";
+import { layoutPosWithNodePair } from "@/app/const/edge-cdt-node-pair-animation";
+import type { NodePairTransform } from "@/app/const/edge-cdt-node-pair-animation";
 
 /** 同一ノード対のエッジをグループ化するキー（ソース・ターゲットの順序を正規化） */
 function getNodePairKey(link: CustomLinkType): string {
@@ -77,6 +80,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
   nodeRef,
   isSelectionMode,
   onNodeSelectionToggle,
+  pairTransform,
 }: {
   graphNode: CustomNodeType;
   isFocused: boolean;
@@ -99,6 +103,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
   nodeRef: React.RefObject<SVGSVGElement>;
   isSelectionMode?: boolean;
   onNodeSelectionToggle?: (node: CustomNodeType) => void;
+  pairTransform?: NodePairTransform | null;
 }) {
   const [imageFailed, setImageFailed] = useState(false);
 
@@ -157,7 +162,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
       key={graphNode.id}
       ref={nodeRef}
       className={`${graphIdentifier}-node cursor-pointer`}
-      transform={`translate(${graphNode.x}, ${graphNode.y})`}
+      transform={`translate(${(graphNode.x ?? 0) + (pairTransform?.dx ?? 0)}, ${(graphNode.y ?? 0) + (pairTransform?.dy ?? 0)})`}
       onClick={() => {
         if (isSelectionMode) {
           onNodeSelectionToggle?.(graphNode);
@@ -174,6 +179,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
         onNodeContextMenu?.(graphNode);
       }}
     >
+      <g transform={pairTransform && pairTransform.scale !== 1 ? `scale(${pairTransform.scale})` : undefined}>
       {showImage ? (
         <>
           <defs>
@@ -240,6 +246,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
           {graphNode.name}
         </text>
       )}
+      </g>
     </g>
   );
 });
@@ -375,6 +382,12 @@ export const D3ForceGraph = ({
     links: linksForEdgeSemanticAnimation,
     enabled: showEdgeSemanticAnimation,
     topicSpaceId,
+  });
+
+  const { getNodePairTransform } = useNodePairSemanticMotion({
+    enabled: showEdgeSemanticAnimation,
+    links: linksForEdgeSemanticAnimation,
+    getEdgeMotionConfig,
   });
 
   const [currentTransformX, setCurrentTransformX] = useState<number>(
@@ -906,6 +919,23 @@ export const D3ForceGraph = ({
                   // );
                   // console.log(gradientFrom, " -> ", gradientTo);
 
+                  const srcPair = showEdgeSemanticAnimation
+                    ? getNodePairTransform(modSource.id)
+                    : null;
+                  const tgtPair = showEdgeSemanticAnimation
+                    ? getNodePairTransform(modTarget.id)
+                    : null;
+                  const srcPos = layoutPosWithNodePair(
+                    modSource.x ?? 0,
+                    modSource.y ?? 0,
+                    srcPair,
+                  );
+                  const tgtPos = layoutPosWithNodePair(
+                    modTarget.x ?? 0,
+                    modTarget.y ?? 0,
+                    tgtPair,
+                  );
+
                   return (
                     <g
                       className="link cursor-pointer"
@@ -924,7 +954,7 @@ export const D3ForceGraph = ({
                     >
                       {cdtMotionConfig ? (
                         <CdtAnimatedEdgePath
-                          pathD={`M ${modSource.x} ${modSource.y} L ${modTarget.x} ${modTarget.y}`}
+                          pathD={`M ${srcPos.x} ${srcPos.y} L ${tgtPos.x} ${tgtPos.y}`}
                           motionConfig={cdtMotionConfig}
                           strokeWidth={
                             ((graphLink.isAddedInHistory ??
@@ -983,10 +1013,10 @@ export const D3ForceGraph = ({
                               linkMagnification *
                               1.5
                           }
-                          x1={modSource.x}
-                          y1={modSource.y}
-                          x2={modTarget.x}
-                          y2={modTarget.y}
+                          x1={srcPos.x}
+                          y1={srcPos.y}
+                          x2={tgtPos.x}
+                          y2={tgtPos.y}
                         />
                       )}
                       {isDirectedLinks && (
@@ -995,10 +1025,10 @@ export const D3ForceGraph = ({
                             stroke={"orange"}
                             strokeWidth={(isFocused ? 2 : 1.2) * 1.5}
                             strokeOpacity={0.1}
-                            x1={modSource.x}
-                            y1={modSource.y}
-                            x2={modTarget.x}
-                            y2={modTarget.y}
+                            x1={srcPos.x}
+                            y1={srcPos.y}
+                            x2={tgtPos.x}
+                            y2={tgtPos.y}
                           >
                             <animate
                               attributeName="stroke-dasharray"
@@ -1022,6 +1052,7 @@ export const D3ForceGraph = ({
                           graphLink={graphLink}
                           getEdgeMotionConfig={getEdgeMotionConfig}
                           displayScale={currentScale}
+                          getNodePairTransform={getNodePairTransform}
                         />
                       )}
                     </g>
@@ -1056,10 +1087,26 @@ export const D3ForceGraph = ({
                       .filter(Boolean);
                     if (typesInPair.length === 0) return null;
 
-                    const labelX = (modSource.x + modTarget.x) / 2;
-                    const labelY = (modSource.y + modTarget.y) / 2;
-                    const dx = modTarget.x - modSource.x;
-                    const dy = modTarget.y - modSource.y;
+                    const srcPair = showEdgeSemanticAnimation
+                      ? getNodePairTransform(modSource.id)
+                      : null;
+                    const tgtPair = showEdgeSemanticAnimation
+                      ? getNodePairTransform(modTarget.id)
+                      : null;
+                    const srcPos = layoutPosWithNodePair(
+                      modSource.x ?? 0,
+                      modSource.y ?? 0,
+                      srcPair,
+                    );
+                    const tgtPos = layoutPosWithNodePair(
+                      modTarget.x ?? 0,
+                      modTarget.y ?? 0,
+                      tgtPair,
+                    );
+                    const labelX = (srcPos.x + tgtPos.x) / 2;
+                    const labelY = (srcPos.y + tgtPos.y) / 2;
+                    const dx = tgtPos.x - srcPos.x;
+                    const dy = tgtPos.y - srcPos.y;
                     const len = Math.sqrt(dx * dx + dy * dy) || 1;
                     const labelTextLength =
                       expandedEdgePairKey === pairKey && pairCount > 1
@@ -1172,6 +1219,7 @@ export const D3ForceGraph = ({
                       nodeRef={nodeRef}
                       isSelectionMode={isSelectionMode}
                       onNodeSelectionToggle={onNodeSelectionToggle}
+                      pairTransform={showEdgeSemanticAnimation ? getNodePairTransform(graphNode.id) : null}
                     />
                   );
                 })}
@@ -1223,6 +1271,7 @@ export const D3ForceGraph = ({
                       nodeRef={nodeRef}
                       isSelectionMode={isSelectionMode}
                       onNodeSelectionToggle={onNodeSelectionToggle}
+                      pairTransform={showEdgeSemanticAnimation ? getNodePairTransform(graphNode.id) : null}
                     />
                   );
                 })}

--- a/src/app/_components/d3/force/storytelling-graph-unified.tsx
+++ b/src/app/_components/d3/force/storytelling-graph-unified.tsx
@@ -40,6 +40,7 @@ import {
 } from "./storytelling-graph/hooks/use-focus-transition";
 import { useSteadyAnimation } from "./storytelling-graph/hooks/use-steady-animation";
 import { useEdgeSemanticAnimation } from "./storytelling-graph/hooks/use-edge-semantic-animation";
+import { useNodePairSemanticMotion } from "./storytelling-graph/hooks/use-node-pair-semantic-motion";
 import { StoryGraphViewportLayer } from "./storytelling-graph/components/story-graph-viewport-layer";
 import { StoryGraphSvgFrame } from "./storytelling-graph/components/story-graph-svg-frame";
 import { StoryGraphContent } from "./storytelling-graph/components/story-graph-content";
@@ -49,6 +50,23 @@ export { easeOutCubic } from "./storytelling-graph/utils/graph-utils";
 
 const NODE_RADIUS = 3;
 const LINK_DISTANCE = 80;
+/** forceLink: 通常エッジの結合強度（0–1） */
+const LINK_STRENGTH_DEFAULT = 0.3;
+/** forceLink: フォーカスエッジの結合強度（通常より強め） */
+const LINK_STRENGTH_FOCUS = 0.5;
+/** コミュニティレイアウト時の同一コミュニティ内エッジ */
+const LINK_STRENGTH_COMMUNITY_INTRA = 0.2;
+/** フォーカス時はリンク距離をやや短くして端点を引き寄せる */
+const LINK_DISTANCE_FOCUS_RATIO = 0.8;
+
+function isFocusLinkForForce(
+  link: CustomLinkType,
+  focusEdgeIdSet: Set<string>,
+  applyFocusForce: boolean,
+): boolean {
+  if (!applyFocusForce) return false;
+  return focusEdgeIdSet.has(getEdgeCompositeKeyFromLink(link));
+}
 /** フォーカスが1点のとき scale が暴れないよう cap する */
 const MAX_VIEW_SCALE = 3;
 /** レイアウト計算用の固定サイズ。冒頭・セグメントで同一シミュレーション結果を使い回すため、実ビューサイズに依存しない */
@@ -290,18 +308,20 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
     [effectiveFocusEdgeIds],
   );
   const hasExplicitEdges = effectiveFocusEdgeIds.length > 0;
-
-  /** エッジ意味アニメーションの分類対象（フォーカスエッジのみ。LLM負荷抑制） */
-  const linksForEdgeSemanticAnimation = useMemo(
-    () =>
-      initLinks.filter((link) =>
-        focusEdgeIdSet.has(getEdgeCompositeKeyFromLink(link)),
-      ),
-    [initLinks, focusEdgeIdSet],
-  );
+  /** セグメント表示時のみフォーカスエッジの forceLink を強化（オーバービューでは全エッジが focus 扱いになるため除外） */
+  const applyFocusLinkForce = hasExplicitEdges && !showFullGraph;
 
   const [nodes, setNodes] = useState<CustomNodeType[]>(initNodes);
   const [links, setLinks] = useState<CustomLinkType[]>(initLinks);
+
+  /** エッジ意味アニメーションの分類対象（フォーカスエッジのみ。シミュレーション後の links を使用） */
+  const linksForEdgeSemanticAnimation = useMemo(
+    () =>
+      links.filter((link) =>
+        focusEdgeIdSet.has(getEdgeCompositeKeyFromLink(link)),
+      ),
+    [links, focusEdgeIdSet],
+  );
   const simulationRef = useRef<Simulation<CustomNodeType, CustomLinkType> | null>(null);
 
   // ── レイアウト transform（useFocusTransition の onFocusWillChange から参照するため先に宣言） ──
@@ -353,10 +373,20 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
       showFullGraph,
     });
 
-  const { getEdgeMotionConfig } = useEdgeSemanticAnimation({
+  const edgeSemanticAnimation = useEdgeSemanticAnimation({
     links: linksForEdgeSemanticAnimation,
     enabled: showEdgeSemanticAnimation,
     topicSpaceId,
+  });
+
+  const { getNodePairTransform } = useNodePairSemanticMotion({
+    enabled:
+      showEdgeSemanticAnimation &&
+      isTransitionComplete &&
+      !freeExploreMode &&
+      !showFullGraph,
+    links: linksForEdgeSemanticAnimation,
+    getEdgeMotionConfig: edgeSemanticAnimation.getEdgeMotionConfig,
   });
 
   useEffect(() => {
@@ -498,14 +528,21 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
           "link",
           forceLink<CustomNodeType, CustomLinkType>(allLinks)
             .id((d) => d.id)
-            .distance(30)
+            .distance((link) => {
+              const base = 30;
+              return isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+                ? base * LINK_DISTANCE_FOCUS_RATIO
+                : base;
+            })
             .strength((link) => {
               const source = link.source as CustomNodeType;
               const target = link.target as CustomNodeType;
               const srcC = communityMap[source.id];
               const tgtC = communityMap[target.id];
               if (srcC && tgtC && srcC !== tgtC) return 0.01;
-              return 0.2;
+              return isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+                ? LINK_STRENGTH_FOCUS
+                : LINK_STRENGTH_COMMUNITY_INTRA;
             }),
         )
         .force("charge", forceManyBody().strength(-200))
@@ -552,8 +589,16 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
         "link",
         forceLink<CustomNodeType, CustomLinkType>(allLinks)
           .id((d) => d.id)
-          .distance(LINK_DISTANCE)
-          .strength(0.3),
+          .distance((link) =>
+            isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+              ? LINK_DISTANCE * LINK_DISTANCE_FOCUS_RATIO
+              : LINK_DISTANCE,
+          )
+          .strength((link) =>
+            isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+              ? LINK_STRENGTH_FOCUS
+              : LINK_STRENGTH_DEFAULT,
+          ),
       )
       .force("charge", forceManyBody().strength(-120))
       .force("center", forceCenter(REF_LAYOUT_WIDTH / 2, REF_LAYOUT_HEIGHT / 2))
@@ -569,14 +614,16 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
     return () => {
       simulation.stop();
     };
-  // height はレイアウト計算に使わず REF_LAYOUT 固定のため依存から除外。
-  // リサイズ時に effect が再実行されると setNodes でノードが再計算され、一瞬グラフが消える現象を防ぐ。
+    // height はレイアウト計算に使わず REF_LAYOUT 固定のため依存から除外。
+    // リサイズ時に effect が再実行されると setNodes でノードが再計算され、一瞬グラフが消える現象を防ぐ。
   }, [
     initNodes,
     initLinks,
     useCommunityLayout,
     communityMap,
     narrativeFlow,
+    focusEdgeIdSet,
+    applyFocusLinkForce,
   ]);
 
   const progress = Math.max(0, Math.min(1, animationProgress * 2));
@@ -1469,9 +1516,9 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
       x: number,
       y: number,
     ): [number, number] => [
-      width / 2 + (x - L.centerX) * L.scale,
-      height / 2 + (y - L.centerY) * L.scale,
-    ];
+        width / 2 + (x - L.centerX) * L.scale,
+        height / 2 + (y - L.centerY) * L.scale,
+      ];
 
     // ノード座標・opacity
     transitionNodeViewCoordsRef.current = new Map(
@@ -1629,7 +1676,10 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
           getNodeLabelFontSize={getNodeLabelFontSize}
           effectiveScaleForLabels={effectiveScaleForLabels}
           draggingNodeId={draggingNodeId}
-          getEdgeMotionConfig={showEdgeSemanticAnimation ? getEdgeMotionConfig : undefined}
+          getEdgeMotionConfig={
+            showEdgeSemanticAnimation ? edgeSemanticAnimation.getEdgeMotionConfig : undefined
+          }
+          getNodePairTransform={showEdgeSemanticAnimation ? getNodePairTransform : undefined}
         />
       </StoryGraphViewportLayer>
     </StoryGraphSvgFrame>

--- a/src/app/_components/d3/force/storytelling-graph/components/story-graph-content.tsx
+++ b/src/app/_components/d3/force/storytelling-graph/components/story-graph-content.tsx
@@ -4,6 +4,10 @@ import { getEdgeCompositeKeyFromLink } from "@/app/const/story-segment";
 import { getMaxEdgeLabelFontSizeByLength } from "@/app/_utils/graph-label-utils";
 import { calcEdgeLabelPos, getDirectionalKey } from "../utils/graph-utils";
 import type { EdgeMotionConfig } from "@/app/const/edge-cdt-animation";
+import {
+  layoutPosWithNodePair,
+  type NodePairTransform,
+} from "@/app/const/edge-cdt-node-pair-animation";
 import { CdtAnimatedEdgePath, CdtEdgeGlowFilterDef } from "./cdt-animated-edge-path";
 import { EdgeSemanticPictogram } from "./edge-semantic-pictogram";
 
@@ -75,6 +79,8 @@ export function StoryGraphContent(props: {
   draggingNodeId: string | null;
   /** CDT分類済みエッジのアニメーション設定を取得する関数。null なら標準描画 */
   getEdgeMotionConfig?: (edgeId: string) => EdgeMotionConfig | null;
+  /** CDTカテゴリに基づくノードペアのビュー空間オフセット+スケール */
+  getNodePairTransform?: (nodeId: string) => NodePairTransform | null;
 }) {
   const {
     graphContentRef,
@@ -117,11 +123,20 @@ export function StoryGraphContent(props: {
     effectiveScaleForLabels,
     draggingNodeId,
     getEdgeMotionConfig,
+    getNodePairTransform,
   } = props;
 
   const hasCdtEdges = pathItemsWithFocusIndex.some(
     (item) => item.hasFocus && getEdgeMotionConfig?.(item.link.id),
   );
+
+  /** レイアウト座標にペアオフセットを加えてからビュー座標へ（エッジ端点・ノード・ラベルで共通） */
+  const nodeViewWithPair = (node: CustomNodeType): [number, number] => {
+    const pair = getNodePairTransform?.(node.id) ?? null;
+    const layout = layoutPosWithNodePair(node.x ?? 0, node.y ?? 0, pair);
+    const [vx, vy] = toView(layout.x, layout.y);
+    return [vx, vy];
+  };
 
   return (
     <g ref={graphContentRef}>
@@ -139,8 +154,8 @@ export function StoryGraphContent(props: {
               const src = link.source as CustomNodeType;
               const tgt = link.target as CustomNodeType;
               if (!src || !tgt || src.x == null || src.y == null || tgt.x == null || tgt.y == null) return null;
-              const [gsx, gsy] = toView(src.x, src.y);
-              const [gtx, gty] = toView(tgt.x, tgt.y);
+              const [gsx, gsy] = nodeViewWithPair(src);
+              const [gtx, gty] = nodeViewWithPair(tgt);
               return (
                 <linearGradient key={`edge-flow-${i}`} id={`edge-flow-${i}`} gradientUnits="userSpaceOnUse" x1={gsx} y1={gsy} x2={gtx} y2={gty}>
                   {edgeFlowStops.map((stop, j) => (
@@ -204,8 +219,8 @@ export function StoryGraphContent(props: {
         const source = link.source as CustomNodeType;
         const target = link.target as CustomNodeType;
         if (!source || !target || source.x == null || source.y == null || target.x == null || target.y == null) return null;
-        const [sx, sy] = toView(source.x, source.y);
-        const [tx, ty] = toView(target.x, target.y);
+        const [sx, sy] = nodeViewWithPair(source);
+        const [tx, ty] = nodeViewWithPair(target);
         const dirKey = getDirectionalKey(link);
         const pathD = `M ${sx} ${sy} L ${tx} ${ty}`;
         const isFocusEdge = item.hasFocus;
@@ -342,8 +357,8 @@ export function StoryGraphContent(props: {
         const showThisEdgeLabel = typesInPair.length > 0 && (showEdgeLabels || (isFocusEdge && !freeExploreMode && !showFullGraph));
         if (!showThisEdgeLabel) return null;
 
-        const [sx, sy] = toView(source.x, source.y);
-        const [tx, ty] = toView(target.x, target.y);
+        const [sx, sy] = nodeViewWithPair(source);
+        const [tx, ty] = nodeViewWithPair(target);
         const len = Math.sqrt((tx - sx) ** 2 + (ty - sy) ** 2) || 1;
 
         const { x: labelX, y: labelY, angle } = calcEdgeLabelPos(sx, sy, tx, ty, hasExplicitEdges, isFocusEdge);
@@ -452,10 +467,12 @@ export function StoryGraphContent(props: {
       {visibleNodesToRender.map((node) => {
         if (node.x == null || node.y == null) return null;
         const isFocusNode = focusNodeIdSet.has(node.id);
-        const [vx, vy] = toView(node.x, node.y);
+        const [vx, vy] = nodeViewWithPair(node);
         const opacity = getNodeOpacity(node);
         const baseR = getNodeRadius(node) * (0.8 / Math.max(1, scaleForSize));
-        const pulseScale = focusNodeIdSet.has(node.id) ? nodePulseScale : 1;
+        const pairXform = getNodePairTransform?.(node.id) ?? null;
+        const basePulse = focusNodeIdSet.has(node.id) ? nodePulseScale : 1;
+        const combinedScale = basePulse * (pairXform?.scale ?? 1);
         const imageUrl = node.properties?.imageUrl as string | undefined;
         const showImage = imageUrl && !failedImageNodeIds.has(node.id);
         const rRaw = imageUrl ? baseR * 2.5 : baseR;
@@ -480,7 +497,7 @@ export function StoryGraphContent(props: {
               }),
             }}
           >
-            <g transform={pulseScale !== 1 ? `scale(${pulseScale})` : undefined}>
+            <g transform={combinedScale !== 1 ? `scale(${combinedScale})` : undefined}>
               {showImage ? (
                 <>
                   <defs>

--- a/src/app/_components/d3/force/storytelling-graph/components/story-graph-content.tsx
+++ b/src/app/_components/d3/force/storytelling-graph/components/story-graph-content.tsx
@@ -6,6 +6,7 @@ import { calcEdgeLabelPos, getDirectionalKey } from "../utils/graph-utils";
 import type { EdgeMotionConfig } from "@/app/const/edge-cdt-animation";
 import {
   layoutPosWithNodePair,
+  nodePairOffsetLayoutScale,
   type NodePairTransform,
 } from "@/app/const/edge-cdt-node-pair-animation";
 import { CdtAnimatedEdgePath, CdtEdgeGlowFilterDef } from "./cdt-animated-edge-path";
@@ -131,9 +132,15 @@ export function StoryGraphContent(props: {
   );
 
   /** レイアウト座標にペアオフセットを加えてからビュー座標へ（エッジ端点・ノード・ラベルで共通） */
+  const pairLayoutScale = nodePairOffsetLayoutScale(displayScale);
   const nodeViewWithPair = (node: CustomNodeType): [number, number] => {
     const pair = getNodePairTransform?.(node.id) ?? null;
-    const layout = layoutPosWithNodePair(node.x ?? 0, node.y ?? 0, pair);
+    const layout = layoutPosWithNodePair(
+      node.x ?? 0,
+      node.y ?? 0,
+      pair,
+      pairLayoutScale,
+    );
     const [vx, vy] = toView(layout.x, layout.y);
     return [vx, vy];
   };

--- a/src/app/_components/d3/force/storytelling-graph/hooks/use-edge-semantic-animation.ts
+++ b/src/app/_components/d3/force/storytelling-graph/hooks/use-edge-semantic-animation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useEffect } from "react";
+import { useCallback, useMemo, useRef, useEffect, useState } from "react";
 import { api } from "@/trpc/react";
 import type { CustomLinkType } from "@/app/const/types";
 import {
@@ -14,6 +14,13 @@ import {
  * 呼び出し元はフォーカス中のエッジのみを links に渡すこと（全エッジ一括分類を避ける）。
  * links（フォーカス集合）が変わったときのみ未分類分をバッチ分類し、結果をメモ化する。
  */
+export type UseEdgeSemanticAnimationResult = {
+  getEdgeMotionConfig: (edgeId: string) => EdgeMotionConfig | null;
+  isLoading: boolean;
+  /** 分類キャッシュ更新のたびに増加（ノードペアモーションの再計算トリガー） */
+  edgeMotionCacheVersion: number;
+};
+
 export function useEdgeSemanticAnimation({
   links,
   enabled,
@@ -22,15 +29,13 @@ export function useEdgeSemanticAnimation({
   links: CustomLinkType[];
   enabled: boolean;
   topicSpaceId?: string;
-}): {
-  getEdgeMotionConfig: (edgeId: string) => EdgeMotionConfig | null;
-  isLoading: boolean;
-} {
+}): UseEdgeSemanticAnimationResult {
   // enabled=false または topicSpaceId 未設定の場合は空を返す
   const isActive = enabled && !!topicSpaceId;
 
   // エッジID → motionConfig のキャッシュ（セッション中に積み上げる）
   const cacheRef = useRef<Map<string, EdgeMotionConfig>>(new Map());
+  const [edgeMotionCacheVersion, setEdgeMotionCacheVersion] = useState(0);
 
   // リクエスト対象のエッジリスト（type が空のものは除外）
   const edgesToClassify = useMemo(() => {
@@ -49,6 +54,7 @@ export function useEdgeSemanticAnimation({
           CDT_ANIMATION_MAP[cdtCategory] ?? CDT_ANIMATION_MAP.MENTAL;
         cacheRef.current.set(result.edgeId, config);
       }
+      setEdgeMotionCacheVersion((v) => v + 1);
     },
   });
 
@@ -64,17 +70,17 @@ export function useEdgeSemanticAnimation({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edgesToClassify, isActive, topicSpaceId]);
 
-  const getEdgeMotionConfig = useMemo<
-    (edgeId: string) => EdgeMotionConfig | null
-  >(() => {
-    if (!isActive) return () => null;
-    return (edgeId: string) => cacheRef.current.get(edgeId) ?? null;
-    // cacheRef.current の変化を依存に含めるため mutation.isSuccess を加える
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActive, mutation.isSuccess, mutation.isPending]);
+  const getEdgeMotionConfig = useCallback(
+    (edgeId: string): EdgeMotionConfig | null => {
+      if (!isActive) return null;
+      return cacheRef.current.get(edgeId) ?? null;
+    },
+    [isActive, edgeMotionCacheVersion],
+  );
 
   return {
     getEdgeMotionConfig,
     isLoading: mutation.isPending,
+    edgeMotionCacheVersion,
   };
 }

--- a/src/app/_components/d3/force/storytelling-graph/hooks/use-node-pair-semantic-motion.ts
+++ b/src/app/_components/d3/force/storytelling-graph/hooks/use-node-pair-semantic-motion.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CustomLinkType, CustomNodeType } from "@/app/const/types";
+import type { EdgeMotionConfig } from "@/app/const/edge-cdt-animation";
+import {
+  CDT_NODE_PAIR_MAP,
+  computeNodePairOffset,
+  getNodePairDurationMs,
+  type NodePairTransform,
+} from "@/app/const/edge-cdt-node-pair-animation";
+
+/**
+ * CDT カテゴリに基づくノードペア間のセマンティック・モーションを駆動するフック。
+ *
+ * エッジのピクトグラム / ストローク・アニメーションと同じ durationMs でループし、
+ * フォーカスエッジの端点ノードにビュー空間オフセット + スケール変位を返す。
+ * レイアウト座標 (node.x, node.y) は変更しない。
+ */
+export function useNodePairSemanticMotion({
+  enabled,
+  links,
+  getEdgeMotionConfig,
+}: {
+  enabled: boolean;
+  links: CustomLinkType[];
+  /** 分類キャッシュ更新時に参照が変わること（useEdgeSemanticAnimation の useCallback 依存） */
+  getEdgeMotionConfig: (edgeId: string) => EdgeMotionConfig | null;
+}): {
+  getNodePairTransform: (nodeId: string) => NodePairTransform | null;
+} {
+  const rafRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  /** nodeId → { category, role, durationMs, edgeVec } for each endpoint of active edges */
+  const activeEntries = useMemo(() => {
+    if (!enabled) return null;
+
+    const entries = new Map<
+      string,
+      {
+        category: EdgeMotionConfig["category"];
+        role: "source" | "target";
+        durationMs: number;
+        edgeVec: { ux: number; uy: number };
+      }
+    >();
+
+    for (const link of links) {
+      const config = getEdgeMotionConfig(link.id);
+      if (!config) continue;
+
+      const src = link.source as CustomNodeType;
+      const tgt = link.target as CustomNodeType;
+      if (!src || !tgt || src.x == null || src.y == null || tgt.x == null || tgt.y == null) continue;
+
+      const dx = tgt.x - src.x;
+      const dy = tgt.y - src.y;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len < 1) continue;
+      const edgeVec = { ux: dx / len, uy: dy / len };
+      const durationMs = getNodePairDurationMs(config.category);
+
+      if (!entries.has(src.id)) {
+        entries.set(src.id, { category: config.category, role: "source", durationMs, edgeVec });
+      }
+      if (!entries.has(tgt.id)) {
+        entries.set(tgt.id, { category: config.category, role: "target", durationMs, edgeVec });
+      }
+    }
+
+    return entries.size > 0 ? entries : null;
+  }, [enabled, links, getEdgeMotionConfig]);
+
+  const shouldAnimate = activeEntries != null;
+
+  useEffect(() => {
+    if (!shouldAnimate) {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      startRef.current = null;
+      setElapsedMs(0);
+      return;
+    }
+
+    const tick = (now: number) => {
+      if (startRef.current == null) {
+        startRef.current = now;
+      }
+      setElapsedMs(now - startRef.current);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [shouldAnimate]);
+
+  const getNodePairTransform = useMemo<
+    (nodeId: string) => NodePairTransform | null
+  >(() => {
+    if (!activeEntries) return () => null;
+
+    return (nodeId: string) => {
+      const entry = activeEntries.get(nodeId);
+      if (!entry) return null;
+
+      const spec = CDT_NODE_PAIR_MAP[entry.category];
+      const t = (elapsedMs % entry.durationMs) / entry.durationMs;
+      return computeNodePairOffset(spec, entry.role, t, entry.edgeVec);
+    };
+  }, [activeEntries, elapsedMs]);
+
+  return { getNodePairTransform };
+}

--- a/src/app/const/edge-cdt-node-pair-animation.ts
+++ b/src/app/const/edge-cdt-node-pair-animation.ts
@@ -1,0 +1,149 @@
+/**
+ * Node Pair Semantic Animation: CDT category → node-pair motion mapping
+ *
+ * Complements edge-cdt-animation.ts (which drives edge stroke / pictogram)
+ * by adding relative motion between the two endpoint nodes of a focused edge.
+ *
+ * All offsets are in view-space pixels and applied as translate/scale deltas
+ * on top of the layout position — the underlying node.x/y are never mutated.
+ */
+
+import type { CdtCategory } from "./edge-cdt-animation";
+import { CDT_ANIMATION_MAP } from "./edge-cdt-animation";
+
+export const NODE_PAIR_MOTION_MODES = [
+  "slideAlong",
+  "attract",
+  "repel",
+  "oscillate",
+  "attractStrong",
+  "repelStrong",
+  "scalePulse",
+  "breathe",
+] as const;
+
+export type NodePairMotionMode = (typeof NODE_PAIR_MOTION_MODES)[number];
+
+export type NodePairMotionSpec = {
+  mode: NodePairMotionMode;
+  /** Max displacement in view-space px (scaled by CDT speed at runtime) */
+  amplitudePx: number;
+  /** When true only the source node moves (e.g. PTRANS directional flow) */
+  driveSourceOnly?: boolean;
+};
+
+export type NodePairTransform = {
+  dx: number;
+  dy: number;
+  scale: number;
+};
+
+export const CDT_NODE_PAIR_MAP: Record<CdtCategory, NodePairMotionSpec> = {
+  PTRANS: { mode: "slideAlong", amplitudePx: 8, driveSourceOnly: true },
+  ATRANS: { mode: "attract", amplitudePx: 6 },
+  PROPEL: { mode: "repel", amplitudePx: 10 },
+  MOVE: { mode: "oscillate", amplitudePx: 5 },
+  INGEST: { mode: "attractStrong", amplitudePx: 12 },
+  EXPEL: { mode: "repelStrong", amplitudePx: 14 },
+  SPEAK: { mode: "scalePulse", amplitudePx: 0 },
+  MENTAL: { mode: "breathe", amplitudePx: 2 },
+};
+
+/**
+ * Compute the view-space transform delta for one endpoint of an edge.
+ *
+ * @param spec      The motion spec for the CDT category
+ * @param role      "source" or "target" — which endpoint this node is
+ * @param t         Normalized loop progress in [0, 1)
+ * @param edgeVec   Unit vector from source → target in view coords: { ux, uy }
+ * @returns         { dx, dy, scale } to apply on top of the node's base position
+ */
+export function computeNodePairOffset(
+  spec: NodePairMotionSpec,
+  role: "source" | "target",
+  t: number,
+  edgeVec: { ux: number; uy: number },
+): NodePairTransform {
+  const { ux, uy } = edgeVec;
+  const a = spec.amplitudePx;
+  const phase = t * Math.PI * 2;
+  // +1 = toward target (along ux), -1 = toward source (against ux)
+  const sign = role === "source" ? 1 : -1;
+
+  switch (spec.mode) {
+    case "slideAlong": {
+      if (spec.driveSourceOnly && role === "target") {
+        return { dx: 0, dy: 0, scale: 1 };
+      }
+      const offset = Math.sin(phase) * a;
+      return { dx: ux * offset, dy: uy * offset, scale: 1 };
+    }
+
+    case "attract": {
+      const pull = (1 - Math.cos(phase)) * 0.5 * a;
+      return { dx: sign * ux * pull, dy: sign * uy * pull, scale: 1 };
+    }
+
+    case "attractStrong": {
+      const pull = (1 - Math.cos(phase)) * 0.5 * a;
+      return { dx: sign * ux * pull, dy: sign * uy * pull, scale: 1 };
+    }
+
+    case "repel": {
+      // Sharp impulse: peaks quickly then decays (abs sine raised to power)
+      const impulse = Math.pow(Math.abs(Math.sin(phase)), 3) * a;
+      return { dx: -sign * ux * impulse, dy: -sign * uy * impulse, scale: 1 };
+    }
+
+    case "repelStrong": {
+      const impulse = Math.pow(Math.abs(Math.sin(phase)), 2) * a;
+      return { dx: -sign * ux * impulse, dy: -sign * uy * impulse, scale: 1 };
+    }
+
+    case "oscillate": {
+      // Perpendicular to edge (normal vector)
+      const nx = -uy;
+      const ny = ux;
+      const wave = Math.sin(phase) * a;
+      const approach = (1 - Math.cos(phase)) * 0.3 * a;
+      return {
+        dx: nx * wave + sign * ux * approach,
+        dy: ny * wave + sign * uy * approach,
+        scale: 1,
+      };
+    }
+
+    case "scalePulse": {
+      const s = 1 + 0.15 * Math.pow(Math.abs(Math.sin(phase)), 2);
+      return { dx: 0, dy: 0, scale: s };
+    }
+
+    case "breathe": {
+      const drift = Math.sin(phase) * a;
+      const s = 1 + 0.04 * (1 - Math.cos(phase));
+      return { dx: ux * drift * sign * 0.3, dy: uy * drift * sign * 0.3, scale: s };
+    }
+
+    default: {
+      return { dx: 0, dy: 0, scale: 1 };
+    }
+  }
+}
+
+/** Retrieve the durationMs for a CDT category (from the edge animation map) */
+export function getNodePairDurationMs(category: CdtCategory): number {
+  return CDT_ANIMATION_MAP[category].durationMs;
+}
+
+/** レイアウト座標にペアオフセットを加算（エッジ端点・ラベル位置用） */
+export function layoutPosWithNodePair(
+  x: number,
+  y: number,
+  pair: NodePairTransform | null,
+  viewScale = 1,
+): { x: number; y: number } {
+  return {
+    x: x + (pair?.dx ?? 0) * viewScale,
+    y: y + (pair?.dy ?? 0) * viewScale,
+  };
+}

--- a/src/app/const/edge-cdt-node-pair-animation.ts
+++ b/src/app/const/edge-cdt-node-pair-animation.ts
@@ -135,6 +135,14 @@ export function getNodePairDurationMs(category: CdtCategory): number {
   return CDT_ANIMATION_MAP[category].durationMs;
 }
 
+/**
+ * amplitudePx（画面ピクセル）をレイアウト座標へ載せるときの係数。
+ * SVG の zoom scale が zoomScale のとき、layout 上は 1/zoomScale 倍する。
+ */
+export function nodePairOffsetLayoutScale(zoomScale: number): number {
+  return zoomScale > 0 ? 1 / zoomScale : 1;
+}
+
 /** レイアウト座標にペアオフセットを加算（エッジ端点・ラベル位置用） */
 export function layoutPosWithNodePair(
   x: number,


### PR DESCRIPTION
- Integrated `getNodePairTransform` functionality into `GraphLinkEdgeSemanticPictogram` and `D3ForceGraph` for improved edge positioning.
- Updated edge rendering logic to utilize transformed positions for source and target nodes, enhancing visual accuracy.
- Refactored `StoryGraphContent` to apply node pair transformations for edge labels and node visuals.
- Enhanced `useEdgeSemanticAnimation` to trigger updates based on edge motion cache version, ensuring smooth animations.