### PR TITLE
feat(story-scroll): add layout focus edge ID calculation for storytel…

### DIFF
--- a/e2e/kg/story-scroll-layout-focus.unit.spec.ts
+++ b/e2e/kg/story-scroll-layout-focus.unit.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import {
+  getLayoutFocusEdgeIdsFromScrollSteps,
+  resolveScrollStepGraphFocus,
+  type ScrollStep,
+} from "@/app/_utils/story-scroll-utils";
+import { getEdgeCompositeKeyFromLink } from "@/app/const/story-segment";
+
+const relationships = [
+  { sourceId: "a", targetId: "b", type: "REL1" },
+  { sourceId: "b", targetId: "c", type: "REL2" },
+];
+
+test.describe("story-scroll layout focus edges", () => {
+  test("resolveScrollStepGraphFocus はコミュニティのみステップを展開する", () => {
+    const step: ScrollStep = {
+      id: "c1-0",
+      communityId: "c1",
+      text: "",
+      nodeIds: [],
+      edgeIds: [],
+    };
+    const communityMap = { a: "c1", b: "c1", c: "other" };
+    const { nodeIds, edgeIds } = resolveScrollStepGraphFocus(
+      step,
+      relationships,
+      communityMap,
+    );
+    expect(nodeIds).toEqual(["a", "b"]);
+    expect(edgeIds).toContain(getEdgeCompositeKeyFromLink(relationships[0]!));
+    expect(edgeIds).not.toContain(getEdgeCompositeKeyFromLink(relationships[1]!));
+  });
+
+  test("getLayoutFocusEdgeIdsFromScrollSteps は全セグメントのフォーカスエッジを union する", () => {
+    const steps: ScrollStep[] = [
+      {
+        id: "s1",
+        communityId: "c1",
+        text: "",
+        nodeIds: ["a", "b"],
+        edgeIds: [],
+      },
+      {
+        id: "s2",
+        communityId: "c1",
+        text: "",
+        nodeIds: ["b", "c"],
+        edgeIds: [],
+      },
+    ];
+    const keys = getLayoutFocusEdgeIdsFromScrollSteps(steps, relationships);
+    expect(keys).toContain(getEdgeCompositeKeyFromLink(relationships[0]!));
+    expect(keys).toContain(getEdgeCompositeKeyFromLink(relationships[1]!));
+  });
+
+  test("__overview__ は layout union に含めない", () => {
+    const steps: ScrollStep[] = [
+      { id: "__overview__", communityId: "", text: "", nodeIds: [], edgeIds: [] },
+      {
+        id: "s1",
+        communityId: "c1",
+        text: "",
+        nodeIds: ["a", "b"],
+        edgeIds: [getEdgeCompositeKeyFromLink(relationships[0]!)],
+      },
+    ];
+    const keys = getLayoutFocusEdgeIdsFromScrollSteps(steps, relationships);
+    expect(keys).toEqual([getEdgeCompositeKeyFromLink(relationships[0]!)]);
+  });
+});

--- a/src/app/_components/article/scroll-storytelling-viewer-unified.tsx
+++ b/src/app/_components/article/scroll-storytelling-viewer-unified.tsx
@@ -12,6 +12,7 @@ import {
 } from "../d3/force/storytelling-graph-unified";
 import {
   buildScrollStepsFromMetaGraphStoryData,
+  getLayoutFocusEdgeIdsFromScrollSteps,
   getSegmentNodeIdsFromMetaGraphStoryData,
   type ScrollStep,
 } from "@/app/_utils/story-scroll-utils";
@@ -411,6 +412,16 @@ export function ScrollStorytellingViewerUnified({
     [metaGraphData],
   );
 
+  const layoutFocusEdgeIds = useMemo(
+    () =>
+      getLayoutFocusEdgeIdsFromScrollSteps(
+        steps,
+        graphDocument?.relationships ?? [],
+        metaGraphData.communityMap,
+      ),
+    [steps, graphDocument?.relationships, metaGraphData.communityMap],
+  );
+
   const animationProgress =
     isFreeExploreMode
       ? 1
@@ -636,6 +647,7 @@ export function ScrollStorytellingViewerUnified({
         onCommunityTitleClick={goToFirstSegmentOfCommunity}
         showEdgeSemanticAnimation={showEdgeSemanticAnimation}
         topicSpaceId={topicSpaceId}
+        layoutFocusEdgeIds={layoutFocusEdgeIds}
       />
 
       {/* グラフの端をフェードさせる軽量な CSS Overlay (SVG Mask の代わり)。PCのみ */}

--- a/src/app/_components/d3/force/storytelling-graph-recorder.tsx
+++ b/src/app/_components/d3/force/storytelling-graph-recorder.tsx
@@ -11,7 +11,11 @@ import React, {
 import type { GraphDocumentForFrontend } from "@/app/const/types";
 import type { MetaGraphStoryData } from "@/app/_hooks/use-meta-graph-story";
 import { StorytellingGraphUnified } from "./storytelling-graph-unified";
-import { buildScrollStepsFromMetaGraphStoryData, getSegmentNodeIdsFromMetaGraphStoryData } from "@/app/_utils/story-scroll-utils";
+import {
+  buildScrollStepsFromMetaGraphStoryData,
+  getLayoutFocusEdgeIdsFromScrollSteps,
+  getSegmentNodeIdsFromMetaGraphStoryData,
+} from "@/app/_utils/story-scroll-utils";
 import { getEdgeCompositeKeyFromLink } from "@/app/const/story-segment";
 import { createSvgToCanvasRenderer } from "@/app/_utils/video/svg-to-canvas";
 import type { SvgToCanvasRenderer as SvgToCanvasRendererType } from "@/app/_utils/video/svg-to-canvas";
@@ -154,6 +158,16 @@ export const StorytellingGraphRecorder = forwardRef<
   const segmentNodeIds = useMemo(
     () => getSegmentNodeIdsFromMetaGraphStoryData(metaGraphData),
     [metaGraphData],
+  );
+
+  const layoutFocusEdgeIds = useMemo(
+    () =>
+      getLayoutFocusEdgeIdsFromScrollSteps(
+        steps,
+        graphDocument?.relationships ?? [],
+        metaGraphData.communityMap,
+      ),
+    [steps, graphDocument?.relationships, metaGraphData.communityMap],
   );
 
   // 実際の録画処理（SVGがマウントされた後に呼ばれる）
@@ -356,6 +370,7 @@ export const StorytellingGraphRecorder = forwardRef<
             onTransitionComplete={handleTransitionComplete}
             onSvgRef={onSvgRef}
             forRecording
+            layoutFocusEdgeIds={layoutFocusEdgeIds}
           />
         </div>
       )}

--- a/src/app/_components/d3/force/storytelling-graph-unified.tsx
+++ b/src/app/_components/d3/force/storytelling-graph-unified.tsx
@@ -59,13 +59,12 @@ const LINK_STRENGTH_COMMUNITY_INTRA = 0.2;
 /** フォーカス時はリンク距離をやや短くして端点を引き寄せる */
 const LINK_DISTANCE_FOCUS_RATIO = 0.8;
 
-function isFocusLinkForForce(
+/** 初回レイアウト用: 全セグメント union のフォーカスエッジか（描画フォーカスとは別） */
+function isLayoutFocusLinkForForce(
   link: CustomLinkType,
-  focusEdgeIdSet: Set<string>,
-  applyFocusForce: boolean,
+  layoutFocusEdgeIdSet: Set<string>,
 ): boolean {
-  if (!applyFocusForce) return false;
-  return focusEdgeIdSet.has(getEdgeCompositeKeyFromLink(link));
+  return layoutFocusEdgeIdSet.has(getEdgeCompositeKeyFromLink(link));
 }
 /** フォーカスが1点のとき scale が暴れないよう cap する */
 const MAX_VIEW_SCALE = 3;
@@ -132,6 +131,8 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
   forRecording = false,
   showEdgeSemanticAnimation = false,
   topicSpaceId,
+  /** 初回 force レイアウトで strength/distance を強めるエッジ（全セグメント分の union）。未指定なら強化なし */
+  layoutFocusEdgeIds,
 }: {
   graphDocument: GraphDocumentForFrontend;
   focusNodeIds: string[];
@@ -171,6 +172,7 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
   showEdgeSemanticAnimation?: boolean;
   /** エッジ分類キャッシュに使用する TopicSpace ID */
   topicSpaceId?: string;
+  layoutFocusEdgeIds?: string[];
 }) {
   const showBottomFadeGradient = !isPc;
   // PC版のフェードは親コンテナ（CSS Overlay）で行うため、ここでは SVG Mask を生成しない（描画負荷軽減）
@@ -308,8 +310,16 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
     [effectiveFocusEdgeIds],
   );
   const hasExplicitEdges = effectiveFocusEdgeIds.length > 0;
-  /** セグメント表示時のみフォーカスエッジの forceLink を強化（オーバービューでは全エッジが focus 扱いになるため除外） */
-  const applyFocusLinkForce = hasExplicitEdges && !showFullGraph;
+
+  /** 初回シミュレーションのみ: 全セグメントのフォーカスエッジ union（セグメント切替では再計算しない） */
+  const layoutFocusEdgeIdSet = useMemo(
+    () => new Set(layoutFocusEdgeIds ?? []),
+    [layoutFocusEdgeIds],
+  );
+  const layoutFocusEdgeIdsKey = useMemo(
+    () => (layoutFocusEdgeIds ?? []).join("|"),
+    [layoutFocusEdgeIds],
+  );
 
   const [nodes, setNodes] = useState<CustomNodeType[]>(initNodes);
   const [links, setLinks] = useState<CustomLinkType[]>(initLinks);
@@ -530,7 +540,7 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
             .id((d) => d.id)
             .distance((link) => {
               const base = 30;
-              return isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+              return isLayoutFocusLinkForForce(link, layoutFocusEdgeIdSet)
                 ? base * LINK_DISTANCE_FOCUS_RATIO
                 : base;
             })
@@ -540,7 +550,7 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
               const srcC = communityMap[source.id];
               const tgtC = communityMap[target.id];
               if (srcC && tgtC && srcC !== tgtC) return 0.01;
-              return isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+              return isLayoutFocusLinkForForce(link, layoutFocusEdgeIdSet)
                 ? LINK_STRENGTH_FOCUS
                 : LINK_STRENGTH_COMMUNITY_INTRA;
             }),
@@ -590,12 +600,12 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
         forceLink<CustomNodeType, CustomLinkType>(allLinks)
           .id((d) => d.id)
           .distance((link) =>
-            isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+            isLayoutFocusLinkForForce(link, layoutFocusEdgeIdSet)
               ? LINK_DISTANCE * LINK_DISTANCE_FOCUS_RATIO
               : LINK_DISTANCE,
           )
           .strength((link) =>
-            isFocusLinkForForce(link, focusEdgeIdSet, applyFocusLinkForce)
+            isLayoutFocusLinkForForce(link, layoutFocusEdgeIdSet)
               ? LINK_STRENGTH_FOCUS
               : LINK_STRENGTH_DEFAULT,
           ),
@@ -614,16 +624,14 @@ export const StorytellingGraphUnified = memo(function StorytellingGraphUnified({
     return () => {
       simulation.stop();
     };
-    // height はレイアウト計算に使わず REF_LAYOUT 固定のため依存から除外。
-    // リサイズ時に effect が再実行されると setNodes でノードが再計算され、一瞬グラフが消える現象を防ぐ。
+    // height / focusEdgeIdSet は依存に含めない（セグメント切替でレイアウト座標を再計算しない）。
   }, [
     initNodes,
     initLinks,
     useCommunityLayout,
     communityMap,
     narrativeFlow,
-    focusEdgeIdSet,
-    applyFocusLinkForce,
+    layoutFocusEdgeIdsKey,
   ]);
 
   const progress = Math.max(0, Math.min(1, animationProgress * 2));

--- a/src/app/_utils/story-scroll-utils.ts
+++ b/src/app/_utils/story-scroll-utils.ts
@@ -1,4 +1,5 @@
 import type { MetaGraphStoryData } from "@/app/_hooks/use-meta-graph-story";
+import { getEdgeCompositeKeyFromLink } from "@/app/const/story-segment";
 
 export interface ScrollStep {
   id: string;
@@ -10,6 +11,12 @@ export interface ScrollStep {
   /** コミュニティ間の繋がり文（transitionText）のステップなら true */
   isTransition?: boolean;
 }
+
+/** レイアウト用フォーカス解決に必要なステップフィールド（RecordingStep 等も可） */
+export type ScrollStepGraphFocus = Pick<
+  ScrollStep,
+  "id" | "communityId" | "nodeIds" | "edgeIds"
+>;
 
 /**
  * MetaGraphStoryData からスクローリーテリング用のステップ配列を組み立てる。
@@ -148,4 +155,94 @@ export function getSegmentNodeIdsFromMetaGraphStoryData(
   const ids = new Set<string>();
   steps.forEach((s) => s.nodeIds.forEach((id) => ids.add(id)));
   return Array.from(ids);
+}
+
+type StoryRelationship = {
+  sourceId: string;
+  targetId: string;
+  type: string;
+};
+
+/** コミュニティのみ指定のステップを、グラフ表示時と同様に nodeIds/edgeIds へ展開する */
+export function resolveScrollStepGraphFocus(
+  step: ScrollStepGraphFocus,
+  relationships: StoryRelationship[],
+  communityMap?: Record<string, string>,
+): { nodeIds: string[]; edgeIds: string[] } {
+  if (step.id === "__overview__") {
+    return { nodeIds: [], edgeIds: [] };
+  }
+
+  let nodeIds = step.nodeIds;
+  let edgeIds = step.edgeIds;
+
+  if (
+    nodeIds.length === 0 &&
+    edgeIds.length === 0 &&
+    step.communityId &&
+    communityMap
+  ) {
+    nodeIds = Object.entries(communityMap)
+      .filter(([, cid]) => cid === step.communityId)
+      .map(([nodeId]) => nodeId);
+    const nodeSet = new Set(nodeIds);
+    edgeIds = relationships
+      .filter((rel) => nodeSet.has(rel.sourceId) && nodeSet.has(rel.targetId))
+      .map((rel) => getEdgeCompositeKeyFromLink(rel));
+  }
+
+  return { nodeIds, edgeIds };
+}
+
+/**
+ * 全セグメントのフォーカスエッジを union し、初回 force レイアウト用の composite key 一覧を返す。
+ * 描画フォーカス（現在セグメント）とは独立。セグメント切替でシミュレーションを再実行しないため。
+ */
+export function getLayoutFocusEdgeIdsFromScrollSteps(
+  steps: ScrollStepGraphFocus[],
+  relationships: StoryRelationship[],
+  communityMap?: Record<string, string>,
+): string[] {
+  const edgeSet = new Set<string>();
+
+  for (const step of steps) {
+    if (step.id === "__overview__") continue;
+
+    const { nodeIds: stepNodeIds, edgeIds: stepEdgeIds } = resolveScrollStepGraphFocus(
+      step,
+      relationships,
+      communityMap,
+    );
+
+    const focusNodeSet = new Set(stepNodeIds);
+    for (const key of stepEdgeIds) {
+      edgeSet.add(key);
+      const rel = relationships.find((r) => getEdgeCompositeKeyFromLink(r) === key);
+      if (rel) {
+        focusNodeSet.add(rel.sourceId);
+        focusNodeSet.add(rel.targetId);
+      }
+    }
+
+    for (const rel of relationships) {
+      if (focusNodeSet.has(rel.sourceId) && focusNodeSet.has(rel.targetId)) {
+        edgeSet.add(getEdgeCompositeKeyFromLink(rel));
+      }
+    }
+  }
+
+  return Array.from(edgeSet);
+}
+
+/** MetaGraphStoryData から初回レイアウト用フォーカスエッジ ID を取得 */
+export function getLayoutFocusEdgeIdsFromMetaGraphStoryData(
+  metaGraphData: MetaGraphStoryData,
+  relationships: StoryRelationship[],
+): string[] {
+  const steps = buildScrollStepsFromMetaGraphStoryData(metaGraphData);
+  return getLayoutFocusEdgeIdsFromScrollSteps(
+    steps,
+    relationships,
+    metaGraphData.communityMap,
+  );
 }

--- a/src/app/_utils/story-scroll-utils.ts
+++ b/src/app/_utils/story-scroll-utils.ts
@@ -163,11 +163,40 @@ type StoryRelationship = {
   type: string;
 };
 
+function buildCommunityNodeIdsMap(
+  communityMap: Record<string, string>,
+): Map<string, string[]> {
+  const byCommunity = new Map<string, string[]>();
+  for (const [nodeId, communityId] of Object.entries(communityMap)) {
+    const list = byCommunity.get(communityId);
+    if (list) list.push(nodeId);
+    else byCommunity.set(communityId, [nodeId]);
+  }
+  return byCommunity;
+}
+
+function buildRelationshipIndexes(relationships: StoryRelationship[]) {
+  const relByCompositeKey = new Map<string, StoryRelationship>();
+  const incidentByNodeId = new Map<string, StoryRelationship[]>();
+
+  for (const rel of relationships) {
+    relByCompositeKey.set(getEdgeCompositeKeyFromLink(rel), rel);
+    for (const nodeId of [rel.sourceId, rel.targetId]) {
+      const list = incidentByNodeId.get(nodeId);
+      if (list) list.push(rel);
+      else incidentByNodeId.set(nodeId, [rel]);
+    }
+  }
+
+  return { relByCompositeKey, incidentByNodeId };
+}
+
 /** コミュニティのみ指定のステップを、グラフ表示時と同様に nodeIds/edgeIds へ展開する */
 export function resolveScrollStepGraphFocus(
   step: ScrollStepGraphFocus,
   relationships: StoryRelationship[],
   communityMap?: Record<string, string>,
+  communityNodeIds?: Map<string, string[]>,
 ): { nodeIds: string[]; edgeIds: string[] } {
   if (step.id === "__overview__") {
     return { nodeIds: [], edgeIds: [] };
@@ -182,9 +211,11 @@ export function resolveScrollStepGraphFocus(
     step.communityId &&
     communityMap
   ) {
-    nodeIds = Object.entries(communityMap)
-      .filter(([, cid]) => cid === step.communityId)
-      .map(([nodeId]) => nodeId);
+    nodeIds =
+      communityNodeIds?.get(step.communityId) ??
+      Object.entries(communityMap)
+        .filter(([, cid]) => cid === step.communityId)
+        .map(([nodeId]) => nodeId);
     const nodeSet = new Set(nodeIds);
     edgeIds = relationships
       .filter((rel) => nodeSet.has(rel.sourceId) && nodeSet.has(rel.targetId))
@@ -192,6 +223,23 @@ export function resolveScrollStepGraphFocus(
   }
 
   return { nodeIds, edgeIds };
+}
+
+function addIntraFocusEdgesForStep(
+  focusNodeSet: Set<string>,
+  edgeSet: Set<string>,
+  incidentByNodeId: Map<string, StoryRelationship[]>,
+): void {
+  const visitedRel = new Set<StoryRelationship>();
+  for (const nodeId of focusNodeSet) {
+    for (const rel of incidentByNodeId.get(nodeId) ?? []) {
+      if (visitedRel.has(rel)) continue;
+      visitedRel.add(rel);
+      if (focusNodeSet.has(rel.sourceId) && focusNodeSet.has(rel.targetId)) {
+        edgeSet.add(getEdgeCompositeKeyFromLink(rel));
+      }
+    }
+  }
 }
 
 /**
@@ -204,6 +252,10 @@ export function getLayoutFocusEdgeIdsFromScrollSteps(
   communityMap?: Record<string, string>,
 ): string[] {
   const edgeSet = new Set<string>();
+  const { relByCompositeKey, incidentByNodeId } = buildRelationshipIndexes(relationships);
+  const communityNodeIds = communityMap
+    ? buildCommunityNodeIdsMap(communityMap)
+    : undefined;
 
   for (const step of steps) {
     if (step.id === "__overview__") continue;
@@ -212,23 +264,20 @@ export function getLayoutFocusEdgeIdsFromScrollSteps(
       step,
       relationships,
       communityMap,
+      communityNodeIds,
     );
 
     const focusNodeSet = new Set(stepNodeIds);
     for (const key of stepEdgeIds) {
       edgeSet.add(key);
-      const rel = relationships.find((r) => getEdgeCompositeKeyFromLink(r) === key);
+      const rel = relByCompositeKey.get(key);
       if (rel) {
         focusNodeSet.add(rel.sourceId);
         focusNodeSet.add(rel.targetId);
       }
     }
 
-    for (const rel of relationships) {
-      if (focusNodeSet.has(rel.sourceId) && focusNodeSet.has(rel.targetId)) {
-        edgeSet.add(getEdgeCompositeKeyFromLink(rel));
-      }
-    }
+    addIntraFocusEdgesForStep(focusNodeSet, edgeSet, incidentByNodeId);
   }
 
   return Array.from(edgeSet);


### PR DESCRIPTION
…ling components

- Implemented `getLayoutFocusEdgeIdsFromScrollSteps` to aggregate focus edge IDs for initial layout in storytelling components.
- Updated `ScrollStorytellingViewerUnified` and `StorytellingGraphRecorder` to utilize the new focus edge IDs for enhanced rendering.
- Refactored `isFocusLinkForForce` to `isLayoutFocusLinkForForce` for clarity in focus link determination during force layout calculations.
- Enhanced `story-scroll-utils` with new utility functions for focus edge resolution and layout management.