### PR TITLE
feat: field research Phase 1 API

### DIFF
--- a/e2e/kg/scan-create-from-scan.integration.spec.ts
+++ b/e2e/kg/scan-create-from-scan.integration.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import { createFromScan } from "@/server/services/scan/create-from-scan.service";
+import { isIntegrationDatabaseReady } from "../helpers/db-ready";
+import {
+  deleteTestDocumentGraph,
+  getOrCreateTestAdminUser,
+  testDb,
+} from "../helpers/test-db";
+
+const hasOpenAiKey = Boolean(process.env.OPENAI_API_KEY);
+const hasSupabase =
+  Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL) &&
+  Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+
+test.describe("createFromScan", () => {
+  test.describe.configure({ mode: "serial" });
+  test.skip(
+    !isIntegrationDatabaseReady(),
+    "DATABASE_URL が未設定、または DB に接続できません（supabase start 等を確認）",
+  );
+
+  test.afterAll(async () => {
+    await testDb.$disconnect();
+  });
+
+  test("OCR テキストから SourceDocument + Graph を作成する", async () => {
+    test.skip(!hasOpenAiKey, "OPENAI_API_KEY が未設定のため LLM 抽出テストをスキップ");
+    test.skip(!hasSupabase, "Supabase 環境変数が未設定のため upload テストをスキップ");
+
+    const user = await getOrCreateTestAdminUser();
+    const plainText =
+      "村上隆は1962年に生まれ、当代美術の代表的なアーティストとして知られている。";
+
+    const result = await createFromScan(
+      { db: testDb, session: { user: { id: user.id } } },
+      {
+        name: `scan-create-from-scan-${Date.now()}`,
+        plainText,
+        ocrMetadata: {
+          engine: "tesseract.js",
+          language: "jpn",
+        },
+      },
+    );
+
+    try {
+      expect(result.sourceDocument.documentType).toBe("INPUT_SCAN");
+      expect(result.sourceDocument.url).toContain("http");
+      expect(result.graph.dataJson.nodes.length).toBeGreaterThan(0);
+      expect(Array.isArray(result.matchCandidates)).toBe(true);
+    } finally {
+      await deleteTestDocumentGraph(
+        result.graph.id,
+        result.sourceDocument.id,
+      );
+    }
+  });
+});

--- a/e2e/kg/scan-source-document.integration.spec.ts
+++ b/e2e/kg/scan-source-document.integration.spec.ts
@@ -1,0 +1,67 @@
+import { createId } from "@paralleldrive/cuid2";
+import { test, expect } from "@playwright/test";
+import { DocumentType } from "@prisma/client";
+import { createSourceDocumentWithGraph } from "@/server/services/kg/create-source-document-with-graph.service";
+import { isIntegrationDatabaseReady } from "../helpers/db-ready";
+import {
+  deleteTestDocumentGraph,
+  getOrCreateTestAdminUser,
+  testDb,
+} from "../helpers/test-db";
+
+test.describe("scan SourceDocument fields", () => {
+  test.describe.configure({ mode: "serial" });
+  test.skip(
+    !isIntegrationDatabaseReady(),
+    "DATABASE_URL が未設定、または DB に接続できません（supabase start 等を確認）",
+  );
+
+  test.afterAll(async () => {
+    await testDb.$disconnect();
+  });
+
+  test("INPUT_SCAN と ocrMetadata / sourceImageUrl を保存できる", async () => {
+    const user = await getOrCreateTestAdminUser();
+    const nodeId = createId();
+    const ocrMetadata = {
+      engine: "tesseract.js",
+      language: "jpn",
+      confidence: 0.91,
+      processedAt: new Date().toISOString(),
+    };
+
+    const { documentGraph, sourceDocument } =
+      await createSourceDocumentWithGraph(
+        { db: testDb, session: { user: { id: user.id } } },
+        {
+          name: "scan-source-document-test",
+          url: "https://example.com/scan-text.txt",
+          documentType: DocumentType.INPUT_SCAN,
+          sourceImageUrl: "https://example.com/scan-image.jpg",
+          ocrMetadata,
+          dataJson: {
+            nodes: [
+              {
+                id: nodeId,
+                name: "ScanSeedNode",
+                label: "Entity",
+                properties: {},
+              },
+            ],
+            relationships: [],
+          },
+        },
+      );
+
+    try {
+      const saved = await testDb.sourceDocument.findUniqueOrThrow({
+        where: { id: sourceDocument.id },
+      });
+      expect(saved.documentType).toBe(DocumentType.INPUT_SCAN);
+      expect(saved.sourceImageUrl).toBe("https://example.com/scan-image.jpg");
+      expect(saved.ocrMetadata).toEqual(ocrMetadata);
+    } finally {
+      await deleteTestDocumentGraph(documentGraph.id, sourceDocument.id);
+    }
+  });
+});

--- a/e2e/kg/search-published-nodes.integration.spec.ts
+++ b/e2e/kg/search-published-nodes.integration.spec.ts
@@ -1,0 +1,71 @@
+import { createId } from "@paralleldrive/cuid2";
+import { test, expect } from "@playwright/test";
+import { WorkspaceStatus } from "@prisma/client";
+import { searchPublishedNodes } from "@/server/services/workspace/search-published-nodes.service";
+import { isIntegrationDatabaseReady } from "../helpers/db-ready";
+import {
+  createTestTopicSpaceWithAdmin,
+  deleteTestTopicSpace,
+  getOrCreateTestAdminUser,
+  testDb,
+} from "../helpers/test-db";
+
+test.describe("searchPublishedNodes", () => {
+  test.describe.configure({ mode: "serial" });
+  test.skip(
+    !isIntegrationDatabaseReady(),
+    "DATABASE_URL が未設定、または DB に接続できません（supabase start 等を確認）",
+  );
+
+  test.afterAll(async () => {
+    await testDb.$disconnect();
+  });
+
+  test("公開 Workspace 内ノードを部分一致検索できる", async () => {
+    const user = await getOrCreateTestAdminUser();
+    const { topicSpace } = await createTestTopicSpaceWithAdmin(
+      "pw-search-published",
+    );
+    const nodeId = createId();
+    const uniqueName = `PublishedSearchTarget-${createId()}`;
+
+    const workspace = await testDb.workspace.create({
+      data: {
+        name: `Published WS ${createId()}`,
+        status: WorkspaceStatus.PUBLISHED,
+        userId: user.id,
+        referencedTopicSpaces: { connect: { id: topicSpace.id } },
+      },
+    });
+
+    await testDb.graphNode.create({
+      data: {
+        id: nodeId,
+        name: uniqueName,
+        label: "Artist",
+        properties: {},
+        topicSpaceId: topicSpace.id,
+      },
+    });
+
+    try {
+      const matches = await searchPublishedNodes(
+        { db: testDb },
+        { query: "PublishedSearchTarget", limit: 10 },
+      );
+
+      expect(
+        matches.some(
+          (match) =>
+            match.nodeId === nodeId &&
+            match.workspaceId === workspace.id &&
+            match.topicSpaceId === topicSpace.id,
+        ),
+      ).toBe(true);
+    } finally {
+      await testDb.graphNode.deleteMany({ where: { id: nodeId } });
+      await testDb.workspace.delete({ where: { id: workspace.id } });
+      await deleteTestTopicSpace(topicSpace.id);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e:edge-motion": "playwright test e2e/kg/edge-cdt-animation.unit.spec.ts e2e/kg/edge-motion-classification.unit.spec.ts e2e/kg/classify-edge-motion.integration.spec.ts",
     "test:e2e:ui": "playwright test --ui",
     "mcp:i": "sudo npx @modelcontextprotocol/inspector",
-    "kg:align": "tsx scripts/kg-alignment-agent/index.ts"
+    "kg:align": "tsx scripts/kg-alignment-agent/index.ts",
+    "supabase:ensure-buckets": "tsx scripts/ensure-supabase-storage-buckets.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.6.0",

--- a/prisma/migrations/20260531140000_add_scan_source_document/migration.sql
+++ b/prisma/migrations/20260531140000_add_scan_source_document/migration.sql
@@ -1,0 +1,6 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'INPUT_SCAN';
+
+-- AlterTable
+ALTER TABLE "SourceDocument" ADD COLUMN "sourceImageUrl" TEXT,
+ADD COLUMN "ocrMetadata" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,8 @@ model SourceDocument {
   id        String   @id @default(cuid())
   name      String
   url       String
+  sourceImageUrl String?
+  ocrMetadata    Json?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   isDeleted Boolean  @default(false)
@@ -114,6 +116,7 @@ model SourceDocument {
 enum DocumentType {
   INPUT_PDF
   INPUT_TXT
+  INPUT_SCAN
 }
 
 model DocumentGraph {

--- a/scripts/ensure-supabase-storage-buckets.ts
+++ b/scripts/ensure-supabase-storage-buckets.ts
@@ -1,0 +1,270 @@
+/**
+ * Ensure Supabase Storage buckets required by the app exist (idempotent).
+ *
+ * Usage:
+ *   npm run supabase:ensure-buckets
+ *
+ * Requires local Supabase (`supabase start`) or remote credentials in `.env`.
+ * Set SUPABASE_SERVICE_ROLE_KEY for remote projects; locally the key is read via `supabase status`.
+ */
+import { execSync } from "node:child_process";
+import { config } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import { PrismaClient } from "@prisma/client";
+import { BUCKETS } from "../src/app/_utils/supabase/const";
+
+config();
+
+function isLocalSupabaseUrl(url: string): boolean {
+  return /localhost|127\.0\.0\.1/.test(url);
+}
+
+function readLocalServiceRoleKeyFromCli(): string | null {
+  try {
+    const raw = execSync("supabase status -o json", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const status = JSON.parse(raw) as { SERVICE_ROLE_KEY?: string };
+    return status.SERVICE_ROLE_KEY ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function tryResolveServiceRoleKey(supabaseUrl: string): string | null {
+  if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return process.env.SUPABASE_SERVICE_ROLE_KEY;
+  }
+
+  if (isLocalSupabaseUrl(supabaseUrl)) {
+    return readLocalServiceRoleKeyFromCli();
+  }
+
+  return null;
+}
+
+type BucketSpec = {
+  id: string;
+  public: boolean;
+  fileSizeLimitBytes: number;
+  allowedMimeTypes: string[];
+};
+
+const SCAN_BUCKET: BucketSpec = {
+  id: BUCKETS.PATH_TO_INPUT_SCAN,
+  public: true,
+  fileSizeLimitBytes: 50 * 1024 * 1024,
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+};
+
+async function ensureBucketViaSql(db: PrismaClient, spec: BucketSpec) {
+  await db.$executeRaw`
+    INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+    VALUES (
+      ${spec.id},
+      ${spec.id},
+      ${spec.public},
+      ${spec.fileSizeLimitBytes},
+      ${spec.allowedMimeTypes}::text[]
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      public = EXCLUDED.public,
+      file_size_limit = EXCLUDED.file_size_limit,
+      allowed_mime_types = EXCLUDED.allowed_mime_types
+  `;
+}
+
+async function ensureBucketViaApi(
+  supabaseUrl: string,
+  serviceRoleKey: string,
+  spec: BucketSpec,
+): Promise<"created" | "exists"> {
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: buckets, error: listError } = await admin.storage.listBuckets();
+  if (listError) {
+    throw new Error(`Failed to list buckets: ${listError.message}`);
+  }
+
+  if (buckets?.some((bucket) => bucket.id === spec.id)) {
+    return "exists";
+  }
+
+  const { error: createError } = await admin.storage.createBucket(spec.id, {
+    public: spec.public,
+    fileSizeLimit: spec.fileSizeLimitBytes,
+    allowedMimeTypes: spec.allowedMimeTypes,
+  });
+
+  if (createError) {
+    if (/already exists/i.test(createError.message)) {
+      return "exists";
+    }
+    throw new Error(`Failed to create bucket "${spec.id}": ${createError.message}`);
+  }
+
+  return "created";
+}
+
+async function ensureStoragePolicies(db: PrismaClient, bucketId: string) {
+  const referenceBucket = BUCKETS.PATH_TO_INPUT_TXT;
+  const policies = await db.$queryRaw<
+    Array<{
+      policyname: string;
+      cmd: string;
+      qual: string | null;
+      with_check: string | null;
+    }>
+  >`
+    SELECT policyname, cmd, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND (
+        COALESCE(qual, '') LIKE ${`%${referenceBucket}%`}
+        OR COALESCE(with_check, '') LIKE ${`%${referenceBucket}%`}
+      )
+  `;
+
+  if (policies.length > 0) {
+    for (const policy of policies) {
+      const newPolicyName = policy.policyname.replaceAll(referenceBucket, bucketId);
+      const qual = policy.qual?.replaceAll(referenceBucket, bucketId) ?? null;
+      const withCheck =
+        policy.with_check?.replaceAll(referenceBucket, bucketId) ?? null;
+
+      await db.$executeRawUnsafe(`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = 'storage'
+              AND tablename = 'objects'
+              AND policyname = '${newPolicyName.replace(/'/g, "''")}'
+          ) THEN
+            CREATE POLICY "${newPolicyName.replace(/"/g, '""')}"
+            ON storage.objects
+            FOR ${policy.cmd}
+            ${qual ? `USING (${qual})` : ""}
+            ${withCheck ? `WITH CHECK (${withCheck})` : ""};
+          END IF;
+        END $$;
+      `);
+    }
+    return "copied-from-input-txt";
+  }
+
+  // Fallback when reference policies are not found (e.g. fresh local stack).
+  await db.$executeRawUnsafe(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'storage'
+          AND tablename = 'objects'
+          AND policyname = 'input-scan public read'
+      ) THEN
+        CREATE POLICY "input-scan public read"
+        ON storage.objects FOR SELECT
+        USING (bucket_id = '${bucketId}');
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'storage'
+          AND tablename = 'objects'
+          AND policyname = 'input-scan public insert'
+      ) THEN
+        CREATE POLICY "input-scan public insert"
+        ON storage.objects FOR INSERT
+        WITH CHECK (bucket_id = '${bucketId}');
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'storage'
+          AND tablename = 'objects'
+          AND policyname = 'input-scan public update'
+      ) THEN
+        CREATE POLICY "input-scan public update"
+        ON storage.objects FOR UPDATE
+        USING (bucket_id = '${bucketId}')
+        WITH CHECK (bucket_id = '${bucketId}');
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'storage'
+          AND tablename = 'objects'
+          AND policyname = 'input-scan public delete'
+      ) THEN
+        CREATE POLICY "input-scan public delete"
+        ON storage.objects FOR DELETE
+        USING (bucket_id = '${bucketId}');
+      END IF;
+    END $$;
+  `);
+
+  return "default-public-policies";
+}
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is not set in .env");
+  }
+
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not set in .env");
+  }
+
+  const serviceRoleKey = tryResolveServiceRoleKey(supabaseUrl);
+  const db = new PrismaClient();
+
+  try {
+    let bucketResult: "created" | "exists" | "sql-upserted" = "sql-upserted";
+
+    if (serviceRoleKey) {
+      try {
+        bucketResult = await ensureBucketViaApi(
+          supabaseUrl,
+          serviceRoleKey,
+          SCAN_BUCKET,
+        );
+      } catch (apiError) {
+        console.warn(
+          `[ensure-supabase-storage-buckets] Storage API failed, falling back to SQL: ${
+            apiError instanceof Error ? apiError.message : String(apiError)
+          }`,
+        );
+        await ensureBucketViaSql(db, SCAN_BUCKET);
+        bucketResult = "sql-upserted";
+      }
+    } else {
+      console.warn(
+        "[ensure-supabase-storage-buckets] Service role key unavailable; using SQL upsert. Run `supabase start` or set SUPABASE_SERVICE_ROLE_KEY to use the Storage API.",
+      );
+      await ensureBucketViaSql(db, SCAN_BUCKET);
+    }
+
+    const policyResult = await ensureStoragePolicies(db, SCAN_BUCKET.id);
+
+    console.log(
+      `[ensure-supabase-storage-buckets] bucket "${SCAN_BUCKET.id}": ${bucketResult}`,
+    );
+    console.log(
+      `[ensure-supabase-storage-buckets] storage policies: ${policyResult}`,
+    );
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[ensure-supabase-storage-buckets] ${message}`);
+  process.exit(1);
+});

--- a/src/app/_components/topic-space/document-attach-modal.tsx
+++ b/src/app/_components/topic-space/document-attach-modal.tsx
@@ -36,6 +36,8 @@ const emptyDocument: DocumentResponse = {
   id: "",
   name: "",
   url: "",
+  sourceImageUrl: null,
+  ocrMetadata: null,
   userId: "",
   graph: null,
   createdAt: new Date(),

--- a/src/app/_utils/supabase/const.ts
+++ b/src/app/_utils/supabase/const.ts
@@ -1,12 +1,14 @@
 export const BUCKETS = {
   PATH_TO_INPUT_PDF: "input-pdf",
   PATH_TO_INPUT_TXT: "input-txt",
+  PATH_TO_INPUT_SCAN: "input-scan",
   PATH_TO_SPEECH_AUDIO_FILE: "speech-audio-file",
   PATH_TO_RICH_TEXT_IMAGES: "rich-text-image",
   PATH_TO_NODE_IMAGES: "node-image",
 } as {
   PATH_TO_INPUT_PDF: string;
   PATH_TO_INPUT_TXT: string;
+  PATH_TO_INPUT_SCAN: string;
   PATH_TO_SPEECH_AUDIO_FILE: string;
   PATH_TO_RICH_TEXT_IMAGES: string;
   PATH_TO_NODE_IMAGES: string;

--- a/src/app/_utils/text/text.ts
+++ b/src/app/_utils/text/text.ts
@@ -11,7 +11,7 @@ export const getTextFromDocumentFile = async (
     const loader = new PDFLoader(localFilePath);
     const documents = await loader.load();
     return documents.map((doc) => doc.pageContent).join("\n");
-  } else {
-    return await fetch(url).then((res) => res.text());
   }
+
+  return await fetch(url).then((res) => res.text());
 };

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -17,6 +17,7 @@ import { userRouter } from "./routers/user";
 import { imageRouter } from "./routers/image";
 import { storyRouter } from "./routers/story";
 import { printRouter } from "./routers/print";
+import { scanRouter } from "./routers/scan";
 
 /**
  * This is the primary router for your server.
@@ -42,6 +43,7 @@ export const appRouter = createTRPCRouter({
   image: imageRouter,
   story: storyRouter,
   print: printRouter,
+  scan: scanRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/scan.ts
+++ b/src/server/api/routers/scan.ts
@@ -1,0 +1,11 @@
+import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+import { CreateFromScanInputSchema } from "@/server/api/schemas/scan";
+import { createFromScan } from "@/server/services/scan/create-from-scan.service";
+
+export const scanRouter = createTRPCRouter({
+  createFromScan: protectedProcedure
+    .input(CreateFromScanInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      return createFromScan(ctx, input);
+    }),
+});

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -20,6 +20,8 @@ import {
   type StoryWithRelations,
 } from "@/server/lib/meta-graph-converter";
 import { DEFAULT_EMPTY_WORKSPACE_CONTENT } from "@/app/_constants/workspace-default-content";
+import { SearchPublishedNodesInputSchema } from "@/server/api/schemas/scan";
+import { searchPublishedNodes } from "@/server/services/workspace/search-published-nodes.service";
 
 export const TiptapContentSchema = z.object({
   type: z.string(),
@@ -1144,5 +1146,11 @@ export const workspaceRouter = createTRPCRouter({
         graphDocument,
         metaGraphData,
       };
+    }),
+
+  searchPublishedNodes: protectedProcedure
+    .input(SearchPublishedNodesInputSchema)
+    .query(async ({ ctx, input }) => {
+      return searchPublishedNodes(ctx, input);
     }),
 });

--- a/src/server/api/schemas/scan.ts
+++ b/src/server/api/schemas/scan.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const OcrMetadataSchema = z
+  .object({
+    engine: z.string().optional(),
+    language: z.string().optional(),
+    confidence: z.number().optional(),
+    processedAt: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+export const CreateFromScanInputSchema = z.object({
+  name: z.string().min(1),
+  plainText: z.string().min(1),
+  ocrMetadata: OcrMetadataSchema.optional(),
+  imageDataUrl: z.string().optional(),
+  topicSpaceId: z.string().optional(),
+});
+
+export const SearchPublishedNodesInputSchema = z.object({
+  query: z.string().min(1),
+  workspaceId: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+export const PublishedNodeMatchSchema = z.object({
+  nodeId: z.string(),
+  name: z.string(),
+  label: z.string(),
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  topicSpaceId: z.string(),
+  topicSpaceName: z.string(),
+});
+
+export type OcrMetadata = z.infer<typeof OcrMetadataSchema>;
+export type CreateFromScanInput = z.infer<typeof CreateFromScanInputSchema>;
+export type SearchPublishedNodesInput = z.infer<
+  typeof SearchPublishedNodesInputSchema
+>;
+export type PublishedNodeMatch = z.infer<typeof PublishedNodeMatchSchema>;

--- a/src/server/services/kg/create-source-document-with-graph.service.ts
+++ b/src/server/services/kg/create-source-document-with-graph.service.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient, Prisma } from "@prisma/client";
 import { DocumentType } from "@prisma/client";
 import type {
   NodeTypeForFrontend,
@@ -12,6 +12,9 @@ export type CreateSourceDocumentWithGraphInput = {
   name: string;
   url: string;
   dataJson: z.infer<typeof KnowledgeGraphInputSchema>;
+  documentType?: DocumentType;
+  sourceImageUrl?: string | null;
+  ocrMetadata?: Prisma.InputJsonValue;
 };
 
 type CreateWithGraphCtx = {
@@ -23,9 +26,15 @@ export async function createSourceDocumentWithGraph(
   ctx: CreateWithGraphCtx,
   input: CreateSourceDocumentWithGraphInput,
 ) {
-  const docFileType = await inspectFileTypeFromUrl(input.url);
-  if (!docFileType) {
-    throw new Error("ファイルタイプを判定できませんでした");
+  let documentType = input.documentType;
+
+  if (!documentType) {
+    const docFileType = await inspectFileTypeFromUrl(input.url);
+    if (!docFileType) {
+      throw new Error("ファイルタイプを判定できませんでした");
+    }
+    documentType =
+      docFileType === "pdf" ? DocumentType.INPUT_PDF : DocumentType.INPUT_TXT;
   }
 
   const nodes = input.dataJson.nodes as NodeTypeForFrontend[];
@@ -78,10 +87,9 @@ export async function createSourceDocumentWithGraph(
       data: {
         name: input.name,
         url: input.url,
-        documentType:
-          docFileType === "pdf"
-            ? DocumentType.INPUT_PDF
-            : DocumentType.INPUT_TXT,
+        documentType,
+        sourceImageUrl: input.sourceImageUrl ?? null,
+        ocrMetadata: input.ocrMetadata ?? undefined,
         user: { connect: { id: ctx.session.user.id } },
       },
     });

--- a/src/server/services/scan/create-from-scan.service.ts
+++ b/src/server/services/scan/create-from-scan.service.ts
@@ -1,0 +1,91 @@
+import { DocumentType, type Prisma, type PrismaClient } from "@prisma/client";
+import { BUCKETS } from "@/app/_utils/supabase/const";
+import { storageUtils } from "@/app/_utils/supabase/supabase";
+import { formDocumentGraphForFrontend } from "@/app/_utils/kg/frontend-properties";
+import type { CreateFromScanInput } from "@/server/api/schemas/scan";
+import { KnowledgeGraphInputSchema } from "@/server/api/schemas/knowledge-graph";
+import { runExtractKGFromPlainText } from "@/server/api/routers/kg-extraction";
+import { createSourceDocumentWithGraph } from "@/server/services/kg/create-source-document-with-graph.service";
+import { attachDocumentsToTopicSpace } from "@/server/services/kg/attach-documents.service";
+import {
+  searchPublishedNodesByNames,
+} from "@/server/services/workspace/search-published-nodes.service";
+
+type CreateFromScanCtx = {
+  db: PrismaClient;
+  session: { user: { id: string } };
+};
+
+export async function createFromScan(
+  ctx: CreateFromScanCtx,
+  input: CreateFromScanInput,
+) {
+  const plainText = input.plainText.trim();
+  if (!plainText) {
+    throw new Error("OCR テキストが空です");
+  }
+
+  const textBlob = new Blob([plainText], {
+    type: "text/plain; charset=utf-8",
+  });
+  const textUrl = await storageUtils.uploadFromBlob(
+    textBlob,
+    BUCKETS.PATH_TO_INPUT_TXT,
+  );
+  if (!textUrl) {
+    throw new Error("OCR テキストのアップロードに失敗しました");
+  }
+
+  let sourceImageUrl: string | null = null;
+  if (input.imageDataUrl) {
+    sourceImageUrl = await storageUtils.uploadFromDataURL(
+      input.imageDataUrl,
+      BUCKETS.PATH_TO_INPUT_SCAN,
+    );
+    if (!sourceImageUrl) {
+      throw new Error("スキャン画像のアップロードに失敗しました");
+    }
+  }
+
+  const extracted = await runExtractKGFromPlainText(plainText);
+  if (!extracted) {
+    throw new Error("知識グラフの抽出に失敗しました");
+  }
+  const dataJson = KnowledgeGraphInputSchema.parse(extracted);
+
+  const { documentGraph, sourceDocument } = await createSourceDocumentWithGraph(
+    ctx,
+    {
+      name: input.name,
+      url: textUrl,
+      dataJson,
+      documentType: DocumentType.INPUT_SCAN,
+      sourceImageUrl,
+      ocrMetadata: (input.ocrMetadata ?? undefined) as Prisma.InputJsonValue | undefined,
+    },
+  );
+
+  if (input.topicSpaceId) {
+    await attachDocumentsToTopicSpace(ctx, {
+      id: input.topicSpaceId,
+      documentIds: [sourceDocument.id],
+    });
+  }
+
+  const graphRecord = await ctx.db.documentGraph.findUniqueOrThrow({
+    where: { id: documentGraph.id },
+    include: { graphNodes: true, graphRelationships: true },
+  });
+  const graph = formDocumentGraphForFrontend(graphRecord);
+  const matchCandidates = await searchPublishedNodesByNames(
+    ctx,
+    dataJson.nodes.map((node) => node.name),
+    20,
+  );
+
+  return {
+    sourceDocument,
+    graph,
+    matchCandidates,
+  };
+}

--- a/src/server/services/workspace/search-published-nodes.service.ts
+++ b/src/server/services/workspace/search-published-nodes.service.ts
@@ -1,65 +1,59 @@
-import type { Prisma, PrismaClient } from "@prisma/client";
-import { DocumentType, WorkspaceStatus } from "@prisma/client";
-import type { SearchPublishedNodesInput, PublishedNodeMatch } from "@/server/api/schemas/scan";
+import type { PrismaClient } from "@prisma/client";
+import { WorkspaceStatus } from "@prisma/client";
+import type {
+  SearchPublishedNodesInput,
+  PublishedNodeMatch,
+} from "@/server/api/schemas/scan";
 
 type SearchCtx = {
   db: PrismaClient;
 };
 
-export async function searchPublishedNodes(
-  ctx: SearchCtx,
-  input: SearchPublishedNodesInput,
-): Promise<PublishedNodeMatch[]> {
-  const workspaces = await ctx.db.workspace.findMany({
-    where: {
-      status: WorkspaceStatus.PUBLISHED,
-      isDeleted: false,
-      ...(input.workspaceId ? { id: input.workspaceId } : {}),
-    },
-    select: {
-      id: true,
-      name: true,
-      referencedTopicSpaces: {
-        select: {
-          id: true,
-          name: true,
-          graphNodes: {
-            where: {
-              deletedAt: null,
-              name: {
-                contains: input.query,
-                mode: "insensitive",
-              },
-            },
-            select: {
-              id: true,
-              name: true,
-              label: true,
-            },
-            take: input.limit,
-          },
-        },
-      },
-    },
-  });
+type PublishedNodeRow = {
+  id: string;
+  name: string;
+  label: string;
+  topicSpace: {
+    id: string;
+    name: string;
+    referencedByWorkspaces: Array<{ id: string; name: string }>;
+  } | null;
+};
 
+function publishedWorkspaceFilter(workspaceId?: string) {
+  return {
+    status: WorkspaceStatus.PUBLISHED,
+    isDeleted: false,
+    ...(workspaceId ? { id: workspaceId } : {}),
+  };
+}
+
+function mapNodesToMatches(
+  nodes: PublishedNodeRow[],
+  limit: number,
+): PublishedNodeMatch[] {
   const matches: PublishedNodeMatch[] = [];
+  const seenNodeIds = new Set<string>();
 
-  for (const workspace of workspaces) {
-    for (const topicSpace of workspace.referencedTopicSpaces) {
-      for (const node of topicSpace.graphNodes) {
-        matches.push({
-          nodeId: node.id,
-          name: node.name,
-          label: node.label,
-          workspaceId: workspace.id,
-          workspaceName: workspace.name,
-          topicSpaceId: topicSpace.id,
-          topicSpaceName: topicSpace.name,
-        });
-        if (matches.length >= input.limit) {
-          return matches;
-        }
+  for (const node of nodes) {
+    if (!node.topicSpace) continue;
+
+    for (const workspace of node.topicSpace.referencedByWorkspaces) {
+      if (seenNodeIds.has(node.id)) continue;
+      seenNodeIds.add(node.id);
+
+      matches.push({
+        nodeId: node.id,
+        name: node.name,
+        label: node.label,
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        topicSpaceId: node.topicSpace.id,
+        topicSpaceName: node.topicSpace.name,
+      });
+
+      if (matches.length >= limit) {
+        return matches;
       }
     }
   }
@@ -67,30 +61,92 @@ export async function searchPublishedNodes(
   return matches;
 }
 
+export async function searchPublishedNodes(
+  ctx: SearchCtx,
+  input: SearchPublishedNodesInput,
+): Promise<PublishedNodeMatch[]> {
+  const workspaceFilter = publishedWorkspaceFilter(input.workspaceId);
+
+  const nodes = await ctx.db.graphNode.findMany({
+    where: {
+      deletedAt: null,
+      name: {
+        contains: input.query,
+        mode: "insensitive",
+      },
+      topicSpace: {
+        referencedByWorkspaces: {
+          some: workspaceFilter,
+        },
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      label: true,
+      topicSpace: {
+        select: {
+          id: true,
+          name: true,
+          referencedByWorkspaces: {
+            where: workspaceFilter,
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+    take: input.limit,
+  });
+
+  return mapNodesToMatches(nodes, input.limit);
+}
+
 export async function searchPublishedNodesByNames(
   ctx: SearchCtx,
   nodeNames: string[],
   limit = 20,
 ): Promise<PublishedNodeMatch[]> {
-  const uniqueNames = [...new Set(nodeNames.map((name) => name.trim()).filter(Boolean))];
-  const matches: PublishedNodeMatch[] = [];
-  const seenNodeIds = new Set<string>();
+  const uniqueNames = [
+    ...new Set(nodeNames.map((name) => name.trim()).filter(Boolean)),
+  ];
+  if (uniqueNames.length === 0) return [];
 
-  for (const name of uniqueNames) {
-    if (matches.length >= limit) break;
+  const nodes = await ctx.db.graphNode.findMany({
+    where: {
+      deletedAt: null,
+      name: {
+        in: uniqueNames,
+        mode: "insensitive",
+      },
+      topicSpace: {
+        referencedByWorkspaces: {
+          some: publishedWorkspaceFilter(),
+        },
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      label: true,
+      topicSpace: {
+        select: {
+          id: true,
+          name: true,
+          referencedByWorkspaces: {
+            where: publishedWorkspaceFilter(),
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+    take: limit,
+  });
 
-    const batch = await searchPublishedNodes(ctx, {
-      query: name,
-      limit: Math.min(5, limit - matches.length),
-    });
-
-    for (const match of batch) {
-      if (seenNodeIds.has(match.nodeId)) continue;
-      seenNodeIds.add(match.nodeId);
-      matches.push(match);
-      if (matches.length >= limit) break;
-    }
-  }
-
-  return matches;
+  return mapNodesToMatches(nodes, limit);
 }

--- a/src/server/services/workspace/search-published-nodes.service.ts
+++ b/src/server/services/workspace/search-published-nodes.service.ts
@@ -1,0 +1,96 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { DocumentType, WorkspaceStatus } from "@prisma/client";
+import type { SearchPublishedNodesInput, PublishedNodeMatch } from "@/server/api/schemas/scan";
+
+type SearchCtx = {
+  db: PrismaClient;
+};
+
+export async function searchPublishedNodes(
+  ctx: SearchCtx,
+  input: SearchPublishedNodesInput,
+): Promise<PublishedNodeMatch[]> {
+  const workspaces = await ctx.db.workspace.findMany({
+    where: {
+      status: WorkspaceStatus.PUBLISHED,
+      isDeleted: false,
+      ...(input.workspaceId ? { id: input.workspaceId } : {}),
+    },
+    select: {
+      id: true,
+      name: true,
+      referencedTopicSpaces: {
+        select: {
+          id: true,
+          name: true,
+          graphNodes: {
+            where: {
+              deletedAt: null,
+              name: {
+                contains: input.query,
+                mode: "insensitive",
+              },
+            },
+            select: {
+              id: true,
+              name: true,
+              label: true,
+            },
+            take: input.limit,
+          },
+        },
+      },
+    },
+  });
+
+  const matches: PublishedNodeMatch[] = [];
+
+  for (const workspace of workspaces) {
+    for (const topicSpace of workspace.referencedTopicSpaces) {
+      for (const node of topicSpace.graphNodes) {
+        matches.push({
+          nodeId: node.id,
+          name: node.name,
+          label: node.label,
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          topicSpaceId: topicSpace.id,
+          topicSpaceName: topicSpace.name,
+        });
+        if (matches.length >= input.limit) {
+          return matches;
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+export async function searchPublishedNodesByNames(
+  ctx: SearchCtx,
+  nodeNames: string[],
+  limit = 20,
+): Promise<PublishedNodeMatch[]> {
+  const uniqueNames = [...new Set(nodeNames.map((name) => name.trim()).filter(Boolean))];
+  const matches: PublishedNodeMatch[] = [];
+  const seenNodeIds = new Set<string>();
+
+  for (const name of uniqueNames) {
+    if (matches.length >= limit) break;
+
+    const batch = await searchPublishedNodes(ctx, {
+      query: name,
+      limit: Math.min(5, limit - matches.length),
+    });
+
+    for (const match of batch) {
+      if (seenNodeIds.has(match.nodeId)) continue;
+      seenNodeIds.add(match.nodeId);
+      matches.push(match);
+      if (matches.length >= limit) break;
+    }
+  }
+
+  return matches;
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -73,6 +73,11 @@ file_size_limit = "50MiB"
 [storage.image_transformation]
 enabled = true
 
+[storage.buckets.input-scan]
+public = true
+file_size_limit = "50MiB"
+allowed_mime_types = ["image/jpeg", "image/png", "image/webp", "image/gif"]
+
 # Uncomment to configure local storage buckets
 # [storage.buckets.images]
 # public = false


### PR DESCRIPTION
## Summary

- Phase 0（モノリポ化）は行わず、既存の単一 Next.js 構成のままフィールドリサーチ API（Phase 1）を実装
- `SourceDocument` に `INPUT_SCAN` / `sourceImageUrl` / `ocrMetadata` を追加
- `scan.createFromScan` — OCR テキスト + 任意のスキャン画像 → KG 抽出 → SourceDocument 作成（任意で TopicSpace へ attach）
- `workspace.searchPublishedNodes` — 公開 Workspace 内ノードの部分一致検索
- Supabase バケット定数 `input-scan` を追加

## Prerequisites

- [ ] `npx prisma migrate deploy`（または `npm run db:migrate`）で migration を適用
- [ ] Supabase に `input-scan` バケットを作成（公開設定は既存 `input-txt` と同様）

## Test plan

- [x] `SKIP_ENV_VALIDATION=true npm run build`
- [ ] `npm run test:e2e -- e2e/kg/scan-source-document.integration.spec.ts e2e/kg/search-published-nodes.integration.spec.ts`（要 DB）
- [ ] `e2e/kg/scan-create-from-scan.integration.spec.ts`（要 DB + Supabase + OPENAI_API_KEY）

## Notes

- Phase 0 PR #55 はクローズ済み
- Phase 2（Tesseract.js + `/field` UI）は別 PR


Made with [Cursor](https://cursor.com)