### PR TITLE
feat: field research Phase 2 — /field UI with Tesseract.js OCR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "react-textarea-autosize": "^8.5.5",
         "server-only": "^0.0.1",
         "superjson": "^2.2.1",
+        "tesseract.js": "^7.0.0",
         "three": "^0.169.0",
         "umap-js": "^1.3.0",
         "zod": "^3.23.3",
@@ -1404,9 +1405,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1422,9 +1420,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1442,9 +1437,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1460,9 +1452,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1480,9 +1469,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1498,9 +1484,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1518,9 +1501,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1537,9 +1517,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1555,9 +1532,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1581,9 +1555,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1605,9 +1576,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1631,9 +1599,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1655,9 +1620,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1681,9 +1643,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1706,9 +1665,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1730,9 +1686,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3168,9 +3121,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3186,9 +3136,6 @@
       "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3206,9 +3153,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3225,9 +3169,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3243,9 +3184,6 @@
       "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3638,9 +3576,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3660,9 +3595,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3684,9 +3616,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3706,9 +3635,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3748,9 +3674,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4450,9 +4373,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4468,9 +4388,6 @@
       "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4488,9 +4405,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4506,9 +4420,6 @@
       "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4540,9 +4451,6 @@
       "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6066,9 +5974,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6083,9 +5988,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6100,9 +6002,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6117,9 +6016,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6134,9 +6030,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6151,9 +6044,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6168,9 +6058,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6185,9 +6072,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7039,6 +6923,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -9866,6 +9755,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10569,6 +10459,11 @@
         "@formatjs/icu-messageformat-parser": "^3.4.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
+      "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q=="
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -11133,6 +11028,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -13160,6 +13060,14 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
@@ -14718,6 +14626,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -15927,6 +15840,28 @@
         }
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw=="
+    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -16858,6 +16793,11 @@
       "version": "2.2.8",
       "license": "MIT"
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -17256,6 +17196,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-textarea-autosize": "^8.5.5",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
+    "tesseract.js": "^7.0.0",
     "three": "^0.169.0",
     "umap-js": "^1.3.0",
     "zod": "^3.23.3",

--- a/src/app/_components/animation/fade-in.tsx
+++ b/src/app/_components/animation/fade-in.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useInView } from "react-intersection-observer";
+
 export const FadeIn = ({ children }: { children: React.ReactNode }) => {
   const { ref, inView } = useInView({
-    rootMargin: "-100px",
+    // Exclude only the bottom edge; top inset hid above-the-fold pages like /field.
+    rootMargin: "0px 0px -100px 0px",
     triggerOnce: true,
   });
 

--- a/src/app/const/page-config.ts
+++ b/src/app/const/page-config.ts
@@ -1,5 +1,5 @@
 export const pageConfig = {
-  publicLandingPages: ["/about", "/articles"],
+  publicLandingPages: ["/about", "/articles", "/field"],
   loginProhibitedPages: ["/about"],
 };
 

--- a/src/app/field/page.tsx
+++ b/src/app/field/page.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from "next";
+import { FieldSessionList } from "@/features/field/components/field-session-list";
+
+const Page: NextPage = () => {
+  return (
+    <main className="min-h-screen bg-slate-900 pt-14">
+      <FieldSessionList />
+    </main>
+  );
+};
+
+export default Page;

--- a/src/app/field/scan/[id]/page.tsx
+++ b/src/app/field/scan/[id]/page.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from "next";
+import { FieldScanDetail } from "@/features/field/components/field-scan-detail";
+
+type PageParams = { params: Promise<{ id: string }> };
+
+const Page: NextPage<PageParams> = async ({ params }: PageParams) => {
+  const { id } = await params;
+  if (!id) return null;
+
+  return (
+    <main className="min-h-screen bg-slate-900 pt-14">
+      <FieldScanDetail sessionId={id} />
+    </main>
+  );
+};
+
+export default Page;

--- a/src/app/field/scan/page.tsx
+++ b/src/app/field/scan/page.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from "next";
+import { FieldScanFlow } from "@/features/field/components/field-scan-flow";
+
+const Page: NextPage = () => {
+  return (
+    <main className="min-h-screen bg-slate-900 pt-14">
+      <FieldScanFlow />
+    </main>
+  );
+};
+
+export default Page;

--- a/src/features/field/components/field-scan-detail.tsx
+++ b/src/features/field/components/field-scan-detail.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import dayjs from "dayjs";
+import { api } from "@/trpc/react";
+import { Button } from "@/app/_components/button/button";
+import { FadeIn } from "@/app/_components/animation/fade-in";
+import { GraphSummary } from "@/features/field/components/graph-summary";
+import { PublishedNodeMatches } from "@/features/field/components/published-node-matches";
+
+type FieldScanDetailProps = {
+  sessionId: string;
+};
+
+export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const { data, isLoading, error, refetch } = api.scan.getSession.useQuery({
+    id: sessionId,
+  });
+
+  const trimmedQuery = searchQuery.trim();
+  const { data: searchResults, isFetching: isSearching } =
+    api.workspace.searchPublishedNodes.useQuery(
+      { query: trimmedQuery, limit: 10 },
+      { enabled: trimmedQuery.length >= 2 },
+    );
+
+  const displayedMatches = useMemo(() => {
+    if (trimmedQuery.length >= 2 && searchResults) {
+      return searchResults;
+    }
+    return data?.matchCandidates ?? [];
+  }, [trimmedQuery, searchResults, data?.matchCandidates]);
+
+  if (isLoading) {
+    return (
+      <div className="px-4 py-16 text-center text-sm text-slate-400">
+        読み込み中...
+      </div>
+    );
+  }
+
+  if (error != null || data == null) {
+    return (
+      <div className="mx-auto max-w-lg px-4 py-16 text-center">
+        <p className="mb-4 text-sm text-red-300">
+          スキャンセッションを取得できませんでした
+        </p>
+        <Link href="/field" className="text-sm text-sky-400 hover:underline">
+          一覧に戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <FadeIn>
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-5 px-4 py-6 pb-24">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-bold text-slate-50">{data.name}</h1>
+            <p className="mt-1 text-xs text-slate-400">
+              {dayjs(data.createdAt).format("YYYY/MM/DD HH:mm")}
+            </p>
+          </div>
+          <Link href="/field" className="shrink-0 text-sm text-sky-400 hover:underline">
+            一覧
+          </Link>
+        </div>
+
+        {data.sourceImageUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.sourceImageUrl}
+            alt="スキャン画像"
+            className="max-h-72 w-full rounded-xl object-contain bg-slate-900"
+          />
+        )}
+
+        <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-200">OCR テキスト</h2>
+            {data.ocrMetadata?.confidence != null && (
+              <span className="text-xs text-slate-400">
+                信頼度 {Math.round(Number(data.ocrMetadata.confidence))}%
+              </span>
+            )}
+          </div>
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap text-sm text-slate-200">
+            {data.plainText}
+          </pre>
+        </section>
+
+        <GraphSummary graph={data.graph} />
+
+        <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+          <h2 className="mb-2 text-sm font-semibold text-slate-200">
+            公開ノードを検索
+          </h2>
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="ノード名の一部を入力（2文字以上）"
+            className="mb-3 w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+          />
+          {isSearching && (
+            <p className="mb-2 text-xs text-slate-400">検索中...</p>
+          )}
+          <PublishedNodeMatches
+            matches={displayedMatches}
+            title={
+              trimmedQuery.length >= 2
+                ? "検索結果"
+                : "公開グラフとの一致候補"
+            }
+          />
+        </section>
+
+        <div className="flex flex-col gap-3">
+          <Button
+            onClick={() => router.push(`/graph/${data.graphId}`)}
+            className="w-full bg-slate-700 text-white"
+          >
+            フルグラフビューで開く
+          </Button>
+          <Button
+            onClick={() => void refetch()}
+            className="w-full bg-slate-800 text-slate-100"
+          >
+            一致候補を再取得
+          </Button>
+          <Link
+            href="/field/scan"
+            className="text-center text-sm text-orange-300 hover:underline"
+          >
+            新しいスキャンを追加
+          </Link>
+        </div>
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/features/field/components/field-scan-detail.tsx
+++ b/src/features/field/components/field-scan-detail.tsx
@@ -9,6 +9,8 @@ import { Button } from "@/app/_components/button/button";
 import { FadeIn } from "@/app/_components/animation/fade-in";
 import { GraphSummary } from "@/features/field/components/graph-summary";
 import { PublishedNodeMatches } from "@/features/field/components/published-node-matches";
+import { ScanImageWithRegions } from "@/features/field/components/scan-image-with-regions";
+import type { OcrRegion } from "@/server/api/schemas/scan";
 
 type FieldScanDetailProps = {
   sessionId: string;
@@ -41,6 +43,18 @@ export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
     }
     return data?.matchCandidates ?? [];
   }, [debouncedQuery, searchResults, data?.matchCandidates]);
+
+  const ocrRegions = useMemo((): OcrRegion[] => {
+    const raw = data?.ocrMetadata?.regions;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(
+      (item): item is OcrRegion =>
+        typeof item === "object" &&
+        item != null &&
+        "x" in item &&
+        typeof item.x === "number",
+    );
+  }, [data?.ocrMetadata?.regions]);
 
   if (isLoading) {
     return (
@@ -79,11 +93,9 @@ export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
         </div>
 
         {data.sourceImageUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={data.sourceImageUrl}
-            alt="スキャン画像"
-            className="max-h-72 w-full rounded-xl object-contain bg-slate-900"
+          <ScanImageWithRegions
+            imageUrl={data.sourceImageUrl}
+            regions={ocrRegions}
           />
         )}
 

--- a/src/features/field/components/field-scan-detail.tsx
+++ b/src/features/field/components/field-scan-detail.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import dayjs from "dayjs";
 import { api } from "@/trpc/react";
 import { Button } from "@/app/_components/button/button";
@@ -17,23 +17,30 @@ type FieldScanDetailProps = {
 export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const { data, isLoading, error, refetch } = api.scan.getSession.useQuery({
     id: sessionId,
   });
 
-  const trimmedQuery = searchQuery.trim();
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(searchQuery.trim());
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   const { data: searchResults, isFetching: isSearching } =
     api.workspace.searchPublishedNodes.useQuery(
-      { query: trimmedQuery, limit: 10 },
-      { enabled: trimmedQuery.length >= 2 },
+      { query: debouncedQuery, limit: 10 },
+      { enabled: debouncedQuery.length >= 2 },
     );
 
   const displayedMatches = useMemo(() => {
-    if (trimmedQuery.length >= 2 && searchResults) {
+    if (debouncedQuery.length >= 2 && searchResults) {
       return searchResults;
     }
     return data?.matchCandidates ?? [];
-  }, [trimmedQuery, searchResults, data?.matchCandidates]);
+  }, [debouncedQuery, searchResults, data?.matchCandidates]);
 
   if (isLoading) {
     return (
@@ -112,7 +119,7 @@ export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
           <PublishedNodeMatches
             matches={displayedMatches}
             title={
-              trimmedQuery.length >= 2
+              debouncedQuery.length >= 2
                 ? "検索結果"
                 : "公開グラフとの一致候補"
             }

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -9,9 +9,14 @@ import { Button } from "@/app/_components/button/button";
 import { FadeIn } from "@/app/_components/animation/fade-in";
 import { BUCKETS } from "@/app/_utils/supabase/const";
 import { storageUtils } from "@/app/_utils/supabase/supabase";
+import { ScanRegionSelector } from "@/features/field/components/scan-region-selector";
+import {
+  DEFAULT_OCR_REGION,
+  type NormalizedOcrRegion,
+} from "@/features/field/ocr/region-types";
 import {
   getOcrStatusLabel,
-  runOcr,
+  runOcrOnRegions,
   type OcrLanguage,
   type OcrProgressUpdate,
 } from "@/features/field/ocr/tesseract-client";
@@ -30,6 +35,9 @@ export function FieldScanFlow() {
   const [fileName, setFileName] = useState("");
   const [sessionName, setSessionName] = useState("");
   const [plainText, setPlainText] = useState("");
+  const [ocrRegions, setOcrRegions] = useState<NormalizedOcrRegion[]>([
+    DEFAULT_OCR_REGION,
+  ]);
   const [language, setLanguage] = useState<OcrLanguage>("jpn");
   const [ocrProgress, setOcrProgress] = useState<OcrProgressUpdate | null>(
     null,
@@ -59,8 +67,11 @@ export function FieldScanFlow() {
   }, [previewUrl]);
 
   const canSubmit = useMemo(
-    () => sessionName.trim().length > 0 && plainText.trim().length > 0,
-    [sessionName, plainText],
+    () =>
+      sessionName.trim().length > 0 &&
+      plainText.trim().length > 0 &&
+      ocrRegions.length > 0,
+    [sessionName, plainText, ocrRegions.length],
   );
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -76,6 +87,7 @@ export function FieldScanFlow() {
     setPlainText("");
     setOcrMetadata(undefined);
     setOcrProgress(null);
+    setOcrRegions([DEFAULT_OCR_REGION]);
 
     if (previewUrl) {
       URL.revokeObjectURL(previewUrl);
@@ -97,17 +109,27 @@ export function FieldScanFlow() {
       return;
     }
 
+    if (ocrRegions.length === 0) {
+      setErrorMessage("OCR する文字領域を指定してください");
+      return;
+    }
+
     setIsRunningOcr(true);
     setErrorMessage(null);
     setOcrProgress({ progress: 0, status: "loading tesseract core" });
 
     try {
-      const result = await runOcr(imageFile, language, setOcrProgress);
+      const result = await runOcrOnRegions(
+        imageFile,
+        ocrRegions,
+        language,
+        setOcrProgress,
+      );
       setPlainText(result.plainText);
       setOcrMetadata(result.ocrMetadata);
       if (!result.plainText) {
         setErrorMessage(
-          "テキストを認識できませんでした。言語設定を変えるか、画像を見直してください。",
+          "テキストを認識できませんでした。領域や言語設定を見直してください。",
         );
       }
     } catch (error) {
@@ -179,7 +201,7 @@ export function FieldScanFlow() {
           <div>
             <h1 className="text-xl font-bold text-slate-50">新規スキャン</h1>
             <p className="text-sm text-slate-400">
-              資料を撮影し、OCR → グラフ化 → 公開参照まで進めます
+              資料を撮影し、文字領域を指定 → OCR → グラフ化
             </p>
           </div>
           <Link href="/field" className="text-sm text-sky-400 hover:underline">
@@ -201,19 +223,24 @@ export function FieldScanFlow() {
           {fileName && (
             <p className="mt-2 text-xs text-slate-400">選択中: {fileName}</p>
           )}
-          {previewUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={previewUrl}
-              alt="スキャンプレビュー"
-              className="mt-3 max-h-64 w-full rounded-lg object-contain bg-slate-900"
-            />
-          )}
         </section>
+
+        {previewUrl && (
+          <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+            <label className="mb-2 block text-sm font-medium text-slate-200">
+              2. 文字領域を指定
+            </label>
+            <ScanRegionSelector
+              imageUrl={previewUrl}
+              regions={ocrRegions}
+              onRegionsChange={setOcrRegions}
+            />
+          </section>
+        )}
 
         <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
           <label className="mb-2 block text-sm font-medium text-slate-200">
-            2. OCR 言語
+            3. OCR 言語
           </label>
           <select
             value={language}
@@ -232,18 +259,18 @@ export function FieldScanFlow() {
           <div className="mt-3">
             <Button
               onClick={handleRunOcr}
-              disabled={!imageFile || isRunningOcr}
+              disabled={!imageFile || isRunningOcr || ocrRegions.length === 0}
               isLoading={isRunningOcr}
               className="w-full bg-slate-700 text-white"
             >
-              OCR を実行
+              選択領域で OCR を実行
             </Button>
           </div>
 
           {ocrProgress && (
             <div className="mt-3">
               <div className="mb-1 text-xs text-slate-400">
-                {getOcrStatusLabel(ocrProgress.status)}
+                {getOcrStatusLabel(ocrProgress)}
                 {ocrProgress.status === "recognizing text"
                   ? ` ${Math.round(ocrProgress.progress * 100)}%`
                   : null}
@@ -270,7 +297,7 @@ export function FieldScanFlow() {
             htmlFor="session-name"
             className="mb-2 block text-sm font-medium text-slate-200"
           >
-            3. セッション名
+            4. セッション名
           </label>
           <input
             id="session-name"
@@ -284,7 +311,7 @@ export function FieldScanFlow() {
             htmlFor="ocr-text"
             className="mb-2 block text-sm font-medium text-slate-200"
           >
-            4. OCR テキスト（編集可）
+            5. OCR テキスト（編集可）
           </label>
           <textarea
             id="ocr-text"

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { signIn, useSession } from "next-auth/react";
+import { api } from "@/trpc/react";
+import { Button } from "@/app/_components/button/button";
+import { FadeIn } from "@/app/_components/animation/fade-in";
+import {
+  readFileAsDataUrl,
+  runOcr,
+  type OcrLanguage,
+} from "@/features/field/ocr/tesseract-client";
+
+const LANGUAGE_OPTIONS: { value: OcrLanguage; label: string }[] = [
+  { value: "jpn", label: "日本語（横書き）" },
+  { value: "jpn_vert", label: "日本語（縦書き）" },
+  { value: "eng", label: "English" },
+];
+
+export function FieldScanFlow() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [fileName, setFileName] = useState("");
+  const [sessionName, setSessionName] = useState("");
+  const [plainText, setPlainText] = useState("");
+  const [language, setLanguage] = useState<OcrLanguage>("jpn");
+  const [ocrProgress, setOcrProgress] = useState<number | null>(null);
+  const [ocrMetadata, setOcrMetadata] = useState<
+    Record<string, unknown> | undefined
+  >();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRunningOcr, setIsRunningOcr] = useState(false);
+
+  const createFromScan = api.scan.createFromScan.useMutation({
+    onSuccess: (result) => {
+      router.push(`/field/scan/${result.sourceDocument.id}`);
+    },
+    onError: (error) => {
+      setErrorMessage(error.message ?? "グラフ作成に失敗しました");
+    },
+  });
+
+  const canSubmit = useMemo(
+    () => sessionName.trim().length > 0 && plainText.trim().length > 0,
+    [sessionName, plainText],
+  );
+
+  const handleImageChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setErrorMessage(null);
+    setPlainText("");
+    setOcrMetadata(undefined);
+    setOcrProgress(null);
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setImageDataUrl(dataUrl);
+      setFileName(file.name);
+      if (!sessionName) {
+        setSessionName(file.name.replace(/\.[^.]+$/, "") || "現地スキャン");
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "画像の読み込みに失敗しました",
+      );
+    }
+  };
+
+  const handleRunOcr = async () => {
+    if (!imageDataUrl) {
+      setErrorMessage("先に画像を選択してください");
+      return;
+    }
+
+    setIsRunningOcr(true);
+    setErrorMessage(null);
+    setOcrProgress(0);
+
+    try {
+      const result = await runOcr(imageDataUrl, language, setOcrProgress);
+      setPlainText(result.plainText);
+      setOcrMetadata(result.ocrMetadata);
+      if (!result.plainText) {
+        setErrorMessage(
+          "テキストを認識できませんでした。言語設定を変えるか、画像を見直してください。",
+        );
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "OCR に失敗しました",
+      );
+    } finally {
+      setIsRunningOcr(false);
+      setOcrProgress(null);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+
+    createFromScan.mutate({
+      name: sessionName.trim(),
+      plainText: plainText.trim(),
+      imageDataUrl: imageDataUrl ?? undefined,
+      ocrMetadata,
+    });
+  };
+
+  if (!session) {
+    return (
+      <FadeIn>
+        <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-8">
+          <p className="text-center text-sm text-slate-300">
+            スキャンを保存するにはログインが必要です。
+          </p>
+          <Button
+            onClick={() => signIn("google", { callbackUrl: "/field/scan" })}
+            className="w-full bg-orange-400 text-white hover:bg-orange-500"
+          >
+            Google でログイン
+          </Button>
+        </div>
+      </FadeIn>
+    );
+  }
+
+  return (
+    <FadeIn>
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-5 px-4 py-6 pb-24">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-slate-50">新規スキャン</h1>
+            <p className="text-sm text-slate-400">
+              資料を撮影し、OCR → グラフ化 → 公開参照まで進めます
+            </p>
+          </div>
+          <Link href="/field" className="text-sm text-sky-400 hover:underline">
+            一覧
+          </Link>
+        </div>
+
+        <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+          <label className="mb-2 block text-sm font-medium text-slate-200">
+            1. 画像を選択
+          </label>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            capture="environment"
+            onChange={handleImageChange}
+            className="block w-full text-sm text-slate-300 file:mr-3 file:rounded-md file:border-0 file:bg-slate-700 file:px-3 file:py-2 file:text-slate-100"
+          />
+          {fileName && (
+            <p className="mt-2 text-xs text-slate-400">選択中: {fileName}</p>
+          )}
+          {imageDataUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={imageDataUrl}
+              alt="スキャンプレビュー"
+              className="mt-3 max-h-64 w-full rounded-lg object-contain bg-slate-900"
+            />
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+          <label className="mb-2 block text-sm font-medium text-slate-200">
+            2. OCR 言語
+          </label>
+          <select
+            value={language}
+            onChange={(event) =>
+              setLanguage(event.target.value as OcrLanguage)
+            }
+            className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+          >
+            {LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+
+          <div className="mt-3">
+            <Button
+              onClick={handleRunOcr}
+              disabled={!imageDataUrl || isRunningOcr}
+              isLoading={isRunningOcr}
+              className="w-full bg-slate-700 text-white"
+            >
+              OCR を実行
+            </Button>
+          </div>
+
+          {ocrProgress !== null && (
+            <div className="mt-3">
+              <div className="mb-1 text-xs text-slate-400">
+                認識中 {Math.round(ocrProgress * 100)}%
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-slate-700">
+                <div
+                  className="h-full bg-orange-400 transition-all"
+                  style={{ width: `${Math.round(ocrProgress * 100)}%` }}
+                />
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+          <label
+            htmlFor="session-name"
+            className="mb-2 block text-sm font-medium text-slate-200"
+          >
+            3. セッション名
+          </label>
+          <input
+            id="session-name"
+            value={sessionName}
+            onChange={(event) => setSessionName(event.target.value)}
+            placeholder="例: 展覧会パンフレット p.3"
+            className="mb-4 w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+          />
+
+          <label
+            htmlFor="ocr-text"
+            className="mb-2 block text-sm font-medium text-slate-200"
+          >
+            4. OCR テキスト（編集可）
+          </label>
+          <textarea
+            id="ocr-text"
+            value={plainText}
+            onChange={(event) => setPlainText(event.target.value)}
+            rows={8}
+            placeholder="OCR 結果がここに表示されます。必要に応じて修正してください。"
+            className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+          />
+        </section>
+
+        {errorMessage && (
+          <p className="rounded-lg border border-red-500/40 bg-red-950/40 px-3 py-2 text-sm text-red-300">
+            {errorMessage}
+          </p>
+        )}
+
+        <Button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          isLoading={createFromScan.isPending}
+          className="w-full bg-orange-400 text-white hover:bg-orange-500 disabled:opacity-50"
+        >
+          グラフを作成
+        </Button>
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { signIn, useSession } from "next-auth/react";
 import { api } from "@/trpc/react";
 import { Button } from "@/app/_components/button/button";
 import { FadeIn } from "@/app/_components/animation/fade-in";
+import { BUCKETS } from "@/app/_utils/supabase/const";
+import { storageUtils } from "@/app/_utils/supabase/supabase";
 import {
-  readFileAsDataUrl,
+  getOcrStatusLabel,
   runOcr,
   type OcrLanguage,
+  type OcrProgressUpdate,
 } from "@/features/field/ocr/tesseract-client";
 
 const LANGUAGE_OPTIONS: { value: OcrLanguage; label: string }[] = [
@@ -22,17 +25,21 @@ const LANGUAGE_OPTIONS: { value: OcrLanguage; label: string }[] = [
 export function FieldScanFlow() {
   const router = useRouter();
   const { data: session } = useSession();
-  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [fileName, setFileName] = useState("");
   const [sessionName, setSessionName] = useState("");
   const [plainText, setPlainText] = useState("");
   const [language, setLanguage] = useState<OcrLanguage>("jpn");
-  const [ocrProgress, setOcrProgress] = useState<number | null>(null);
+  const [ocrProgress, setOcrProgress] = useState<OcrProgressUpdate | null>(
+    null,
+  );
   const [ocrMetadata, setOcrMetadata] = useState<
     Record<string, unknown> | undefined
   >();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isRunningOcr, setIsRunningOcr] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const createFromScan = api.scan.createFromScan.useMutation({
     onSuccess: (result) => {
@@ -43,48 +50,59 @@ export function FieldScanFlow() {
     },
   });
 
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
   const canSubmit = useMemo(
     () => sessionName.trim().length > 0 && plainText.trim().length > 0,
     [sessionName, plainText],
   );
 
-  const handleImageChange = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      setErrorMessage("画像ファイルを選択してください。");
+      return;
+    }
 
     setErrorMessage(null);
     setPlainText("");
     setOcrMetadata(undefined);
     setOcrProgress(null);
 
-    try {
-      const dataUrl = await readFileAsDataUrl(file);
-      setImageDataUrl(dataUrl);
-      setFileName(file.name);
-      if (!sessionName) {
-        setSessionName(file.name.replace(/\.[^.]+$/, "") || "現地スキャン");
-      }
-    } catch (error) {
-      setErrorMessage(
-        error instanceof Error ? error.message : "画像の読み込みに失敗しました",
-      );
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
+    setImageFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+    setFileName(file.name);
+
+    if (!sessionName) {
+      const baseName = file.name.replace(/\.[^.]+$/, "");
+      setSessionName(baseName.length > 0 ? baseName : "現地スキャン");
     }
   };
 
   const handleRunOcr = async () => {
-    if (!imageDataUrl) {
+    if (!imageFile) {
       setErrorMessage("先に画像を選択してください");
       return;
     }
 
     setIsRunningOcr(true);
     setErrorMessage(null);
-    setOcrProgress(0);
+    setOcrProgress({ progress: 0, status: "loading tesseract core" });
 
     try {
-      const result = await runOcr(imageDataUrl, language, setOcrProgress);
+      const result = await runOcr(imageFile, language, setOcrProgress);
       setPlainText(result.plainText);
       setOcrMetadata(result.ocrMetadata);
       if (!result.plainText) {
@@ -102,15 +120,38 @@ export function FieldScanFlow() {
     }
   };
 
-  const handleSubmit = () => {
-    if (!canSubmit) return;
+  const handleSubmit = async () => {
+    if (!canSubmit || isSubmitting) return;
 
-    createFromScan.mutate({
-      name: sessionName.trim(),
-      plainText: plainText.trim(),
-      imageDataUrl: imageDataUrl ?? undefined,
-      ocrMetadata,
-    });
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      let sourceImageUrl: string | undefined;
+      if (imageFile) {
+        const uploadedUrl = await storageUtils.upload(
+          imageFile,
+          BUCKETS.PATH_TO_INPUT_SCAN,
+        );
+        if (!uploadedUrl) {
+          throw new Error("スキャン画像のアップロードに失敗しました");
+        }
+        sourceImageUrl = uploadedUrl;
+      }
+
+      await createFromScan.mutateAsync({
+        name: sessionName.trim(),
+        plainText: plainText.trim(),
+        sourceImageUrl,
+        ocrMetadata,
+      });
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "グラフ作成に失敗しました",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   if (!session) {
@@ -160,10 +201,10 @@ export function FieldScanFlow() {
           {fileName && (
             <p className="mt-2 text-xs text-slate-400">選択中: {fileName}</p>
           )}
-          {imageDataUrl && (
+          {previewUrl && (
             // eslint-disable-next-line @next/next/no-img-element
             <img
-              src={imageDataUrl}
+              src={previewUrl}
               alt="スキャンプレビュー"
               className="mt-3 max-h-64 w-full rounded-lg object-contain bg-slate-900"
             />
@@ -191,7 +232,7 @@ export function FieldScanFlow() {
           <div className="mt-3">
             <Button
               onClick={handleRunOcr}
-              disabled={!imageDataUrl || isRunningOcr}
+              disabled={!imageFile || isRunningOcr}
               isLoading={isRunningOcr}
               className="w-full bg-slate-700 text-white"
             >
@@ -199,15 +240,25 @@ export function FieldScanFlow() {
             </Button>
           </div>
 
-          {ocrProgress !== null && (
+          {ocrProgress && (
             <div className="mt-3">
               <div className="mb-1 text-xs text-slate-400">
-                認識中 {Math.round(ocrProgress * 100)}%
+                {getOcrStatusLabel(ocrProgress.status)}
+                {ocrProgress.status === "recognizing text"
+                  ? ` ${Math.round(ocrProgress.progress * 100)}%`
+                  : null}
               </div>
               <div className="h-2 overflow-hidden rounded-full bg-slate-700">
                 <div
                   className="h-full bg-orange-400 transition-all"
-                  style={{ width: `${Math.round(ocrProgress * 100)}%` }}
+                  style={{
+                    width: `${Math.round(
+                      Math.max(
+                        ocrProgress.progress * 100,
+                        ocrProgress.status === "recognizing text" ? 0 : 8,
+                      ),
+                    )}%`,
+                  }}
                 />
               </div>
             </div>
@@ -252,9 +303,9 @@ export function FieldScanFlow() {
         )}
 
         <Button
-          onClick={handleSubmit}
-          disabled={!canSubmit}
-          isLoading={createFromScan.isPending}
+          onClick={() => void handleSubmit()}
+          disabled={!canSubmit || isSubmitting}
+          isLoading={isSubmitting}
           className="w-full bg-orange-400 text-white hover:bg-orange-500 disabled:opacity-50"
         >
           グラフを作成

--- a/src/features/field/components/field-session-list.tsx
+++ b/src/features/field/components/field-session-list.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { signIn, useSession } from "next-auth/react";
+import dayjs from "dayjs";
+import { api } from "@/trpc/react";
+import { Button } from "@/app/_components/button/button";
+import { FadeIn } from "@/app/_components/animation/fade-in";
+
+export function FieldSessionList() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { data, isLoading, error } = api.scan.listSessions.useQuery(
+    { page: 1, limit: 30 },
+    { enabled: !!session },
+  );
+
+  if (!session) {
+    return (
+      <FadeIn>
+        <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-8">
+          <div className="text-center">
+            <h1 className="mb-2 text-2xl font-bold text-slate-50">
+              フィールドリサーチ
+            </h1>
+            <p className="text-sm text-slate-300">
+              現地で撮影した資料から知識グラフを作成し、公開アーカイブと照合できます。
+            </p>
+          </div>
+          <Button
+            onClick={() => signIn("google", { callbackUrl: "/field" })}
+            className="w-full bg-orange-400 text-white hover:bg-orange-500"
+          >
+            Google でログイン
+          </Button>
+        </div>
+      </FadeIn>
+    );
+  }
+
+  return (
+    <FadeIn>
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-6 pb-24">
+        <div>
+          <h1 className="mb-1 text-2xl font-bold text-slate-50">
+            フィールドリサーチ
+          </h1>
+          <p className="text-sm text-slate-300">
+            スキャンセッションの一覧です。新しい資料はカメラから追加できます。
+          </p>
+        </div>
+
+        <Button
+          onClick={() => router.push("/field/scan")}
+          className="w-full bg-orange-400 text-white hover:bg-orange-500"
+        >
+          新規スキャン
+        </Button>
+
+        {isLoading && (
+          <p className="text-center text-sm text-slate-400">読み込み中...</p>
+        )}
+        {error && (
+          <p className="text-center text-sm text-red-400">
+            セッション一覧の取得に失敗しました
+          </p>
+        )}
+
+        {data && data.items.length === 0 && (
+          <div className="rounded-xl border border-dashed border-slate-600 p-6 text-center text-sm text-slate-400">
+            まだスキャンがありません。「新規スキャン」から始めてください。
+          </div>
+        )}
+
+        {data && data.items.length > 0 && (
+          <ul className="flex flex-col gap-3">
+            {data.items.map((item) => (
+              <li key={item.id}>
+                <Link
+                  href={`/field/scan/${item.id}`}
+                  className="flex items-center gap-3 rounded-xl border border-slate-700 bg-slate-800/70 p-3 transition hover:border-orange-400/60"
+                >
+                  {item.sourceImageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={item.sourceImageUrl}
+                      alt=""
+                      className="h-16 w-16 shrink-0 rounded-lg object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-slate-700 text-xs text-slate-300">
+                      画像なし
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium text-slate-50">
+                      {item.name}
+                    </div>
+                    <div className="mt-1 text-xs text-slate-400">
+                      {dayjs(item.createdAt).format("YYYY/MM/DD HH:mm")} · ノード{" "}
+                      {item.nodeCount}
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/features/field/components/field-session-list.tsx
+++ b/src/features/field/components/field-session-list.tsx
@@ -10,11 +10,19 @@ import { FadeIn } from "@/app/_components/animation/fade-in";
 
 export function FieldSessionList() {
   const router = useRouter();
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const { data, isLoading, error } = api.scan.listSessions.useQuery(
     { page: 1, limit: 30 },
     { enabled: !!session },
   );
+
+  if (status === "loading") {
+    return (
+      <div className="mx-auto flex w-full max-w-lg flex-col px-4 py-8">
+        <p className="text-center text-sm text-slate-400">読み込み中...</p>
+      </div>
+    );
+  }
 
   if (!session) {
     return (

--- a/src/features/field/components/graph-summary.tsx
+++ b/src/features/field/components/graph-summary.tsx
@@ -1,0 +1,67 @@
+import type { GraphDocumentForFrontend } from "@/app/const/types";
+
+type GraphSummaryProps = {
+  graph: GraphDocumentForFrontend;
+};
+
+export function GraphSummary({ graph }: GraphSummaryProps) {
+  return (
+    <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-slate-200">抽出グラフ</h2>
+        <span className="text-xs text-slate-400">
+          ノード {graph.nodes.length} · 関係 {graph.relationships.length}
+        </span>
+      </div>
+
+      {graph.nodes.length > 0 && (
+        <div className="mb-4">
+          <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+            ノード
+          </h3>
+          <ul className="flex flex-wrap gap-2">
+            {graph.nodes.map((node) => (
+              <li
+                key={node.id}
+                className="rounded-full border border-slate-600 bg-slate-900 px-3 py-1 text-sm text-slate-100"
+              >
+                {node.name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {graph.relationships.length > 0 && (
+        <div>
+          <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+            関係
+          </h3>
+          <ul className="flex flex-col gap-2">
+            {graph.relationships.map((relationship) => {
+              const source = graph.nodes.find(
+                (node) => node.id === relationship.sourceId,
+              );
+              const target = graph.nodes.find(
+                (node) => node.id === relationship.targetId,
+              );
+              return (
+                <li
+                  key={relationship.id}
+                  className="rounded-lg bg-slate-900/70 px-3 py-2 text-sm text-slate-200"
+                >
+                  {source?.name ?? "?"} → {target?.name ?? "?"}
+                  {relationship.type ? (
+                    <span className="ml-2 text-xs text-slate-400">
+                      ({relationship.type})
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/field/components/graph-summary.tsx
+++ b/src/features/field/components/graph-summary.tsx
@@ -5,6 +5,8 @@ type GraphSummaryProps = {
 };
 
 export function GraphSummary({ graph }: GraphSummaryProps) {
+  const nodesMap = new Map(graph.nodes.map((node) => [node.id, node]));
+
   return (
     <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
       <div className="mb-3 flex items-center justify-between">
@@ -39,12 +41,8 @@ export function GraphSummary({ graph }: GraphSummaryProps) {
           </h3>
           <ul className="flex flex-col gap-2">
             {graph.relationships.map((relationship) => {
-              const source = graph.nodes.find(
-                (node) => node.id === relationship.sourceId,
-              );
-              const target = graph.nodes.find(
-                (node) => node.id === relationship.targetId,
-              );
+              const source = nodesMap.get(relationship.sourceId);
+              const target = nodesMap.get(relationship.targetId);
               return (
                 <li
                   key={relationship.id}

--- a/src/features/field/components/published-node-matches.tsx
+++ b/src/features/field/components/published-node-matches.tsx
@@ -1,0 +1,50 @@
+import type { PublishedNodeMatch } from "@/server/api/schemas/scan";
+import Link from "next/link";
+
+type PublishedNodeMatchesProps = {
+  matches: PublishedNodeMatch[];
+  title?: string;
+  emptyMessage?: string;
+};
+
+export function PublishedNodeMatches({
+  matches,
+  title = "公開グラフとの一致候補",
+  emptyMessage = "一致する公開ノードは見つかりませんでした",
+}: PublishedNodeMatchesProps) {
+  if (matches.length === 0) {
+    return (
+      <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+        <h2 className="mb-2 text-sm font-semibold text-slate-200">{title}</h2>
+        <p className="text-sm text-slate-400">{emptyMessage}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+      <h2 className="mb-3 text-sm font-semibold text-slate-200">{title}</h2>
+      <ul className="flex flex-col gap-3">
+        {matches.map((match) => (
+          <li
+            key={`${match.nodeId}-${match.workspaceId}`}
+            className="rounded-lg border border-slate-700 bg-slate-900/50 p-3"
+          >
+            <div className="mb-1 text-base font-medium text-orange-300">
+              {match.name}
+            </div>
+            <div className="mb-2 text-xs text-slate-400">
+              {match.label} · {match.topicSpaceName}
+            </div>
+            <Link
+              href={`/workspaces/${match.workspaceId}`}
+              className="text-sm text-sky-400 underline-offset-2 hover:underline"
+            >
+              {match.workspaceName} を開く
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/field/components/scan-image-with-regions.tsx
+++ b/src/features/field/components/scan-image-with-regions.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  getDisplayedImageLayout,
+  regionToOverlayStyle,
+  type NormalizedOcrRegion,
+} from "@/features/field/ocr/region-types";
+
+type ScanImageWithRegionsProps = {
+  imageUrl: string;
+  regions?: NormalizedOcrRegion[];
+  alt?: string;
+};
+
+export function ScanImageWithRegions({
+  imageUrl,
+  regions = [],
+  alt = "スキャン画像",
+}: ScanImageWithRegionsProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const [layout, setLayout] = useState<ReturnType<
+    typeof getDisplayedImageLayout
+  > | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || naturalSize.width === 0) return;
+
+    const update = () => {
+      const rect = container.getBoundingClientRect();
+      setLayout(
+        getDisplayedImageLayout(
+          rect.width,
+          rect.height,
+          naturalSize.width,
+          naturalSize.height,
+        ),
+      );
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [naturalSize.height, naturalSize.width]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full overflow-hidden rounded-xl bg-slate-900"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={imageUrl}
+        alt={alt}
+        className="block max-h-72 w-full object-contain"
+        onLoad={(event) => {
+          setNaturalSize({
+            width: event.currentTarget.naturalWidth,
+            height: event.currentTarget.naturalHeight,
+          });
+        }}
+      />
+      {layout &&
+        regions.map((region, index) => (
+          <div
+            key={`saved-region-${index}`}
+            className="pointer-events-none absolute border-2 border-orange-400/80 bg-orange-400/15"
+            style={regionToOverlayStyle(region, layout)}
+          >
+            <span className="absolute left-1 top-1 rounded bg-orange-500/90 px-1 text-[10px] text-white">
+              {index + 1}
+            </span>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/src/features/field/components/scan-region-selector.tsx
+++ b/src/features/field/components/scan-region-selector.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/app/_components/button/button";
+import {
+  clientPointToNormalized,
+  DEFAULT_OCR_REGION,
+  getDisplayedImageLayout,
+  normalizedRectFromPoints,
+  regionToOverlayStyle,
+  type DisplayedImageLayout,
+  type NormalizedOcrRegion,
+} from "@/features/field/ocr/region-types";
+
+type ScanRegionSelectorProps = {
+  imageUrl: string;
+  regions: NormalizedOcrRegion[];
+  onRegionsChange: (regions: NormalizedOcrRegion[]) => void;
+};
+
+type DraftRect = {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+};
+
+export function ScanRegionSelector({
+  imageUrl,
+  regions,
+  onRegionsChange,
+}: ScanRegionSelectorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [layout, setLayout] = useState<DisplayedImageLayout | null>(null);
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const [draft, setDraft] = useState<DraftRect | null>(null);
+  const [addMode, setAddMode] = useState(false);
+  const activePointerId = useRef<number | null>(null);
+
+  const updateLayout = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || naturalSize.width === 0) return;
+
+    const rect = container.getBoundingClientRect();
+    setLayout(
+      getDisplayedImageLayout(
+        rect.width,
+        rect.height,
+        naturalSize.width,
+        naturalSize.height,
+      ),
+    );
+  }, [naturalSize.height, naturalSize.width]);
+
+  useEffect(() => {
+    updateLayout();
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver(updateLayout);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [updateLayout]);
+
+  const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    setNaturalSize({ width: img.naturalWidth, height: img.naturalHeight });
+    if (regions.length === 0) {
+      onRegionsChange([DEFAULT_OCR_REGION]);
+    }
+  };
+
+  const commitDraft = (nextDraft: DraftRect) => {
+    const region = normalizedRectFromPoints(nextDraft.start, nextDraft.end);
+    if (!region) return;
+
+    if (addMode || regions.length === 0) {
+      onRegionsChange([...regions, region]);
+      setAddMode(false);
+      return;
+    }
+
+    onRegionsChange([region]);
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!layout || !containerRef.current) return;
+
+    const point = clientPointToNormalized(
+      event.clientX,
+      event.clientY,
+      containerRef.current.getBoundingClientRect(),
+      layout,
+    );
+    if (!point) return;
+
+    activePointerId.current = event.pointerId;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setDraft({ start: point, end: point });
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (
+      activePointerId.current !== event.pointerId ||
+      !draft ||
+      !layout ||
+      !containerRef.current
+    ) {
+      return;
+    }
+
+    const point = clientPointToNormalized(
+      event.clientX,
+      event.clientY,
+      containerRef.current.getBoundingClientRect(),
+      layout,
+    );
+    if (!point) return;
+
+    setDraft({ ...draft, end: point });
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (activePointerId.current !== event.pointerId || !draft) return;
+
+    commitDraft(draft);
+    setDraft(null);
+    activePointerId.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
+  const draftRegion =
+    draft && layout
+      ? normalizedRectFromPoints(draft.start, draft.end)
+      : null;
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      <p className="text-xs text-slate-400">
+        文字部分を指でドラッグして囲んでください。最初は中央に候補領域を表示しています。
+      </p>
+
+      <div
+        ref={containerRef}
+        className="relative aspect-[3/4] max-h-80 w-full overflow-hidden rounded-lg bg-slate-900"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imageUrl}
+          alt="OCR 領域選択"
+          className="absolute inset-0 h-full w-full object-contain"
+          onLoad={handleImageLoad}
+          draggable={false}
+        />
+
+        <div
+          className="absolute inset-0 touch-none"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
+          {layout &&
+            regions.map((region, index) => (
+              <div
+                key={`region-${index}`}
+                className="pointer-events-none absolute border-2 border-orange-400 bg-orange-400/20"
+                style={regionToOverlayStyle(region, layout)}
+              >
+                <span className="absolute left-1 top-1 rounded bg-orange-500/90 px-1 text-[10px] text-white">
+                  {index + 1}
+                </span>
+              </div>
+            ))}
+
+          {layout && draftRegion && (
+            <div
+              className="pointer-events-none absolute border-2 border-dashed border-sky-300 bg-sky-300/15"
+              style={regionToOverlayStyle(draftRegion, layout)}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          onClick={() => setAddMode(true)}
+          className="bg-slate-700 px-2 py-1 text-xs text-white"
+          size="small"
+        >
+          ＋ 領域を追加
+        </Button>
+        <Button
+          onClick={() => onRegionsChange([DEFAULT_OCR_REGION])}
+          className="bg-slate-700 px-2 py-1 text-xs text-white"
+          size="small"
+        >
+          候補をリセット
+        </Button>
+        {regions.length > 1 && (
+          <Button
+            onClick={() => onRegionsChange(regions.slice(0, -1))}
+            className="bg-slate-700 px-2 py-1 text-xs text-white"
+            size="small"
+          >
+            最後の領域を削除
+          </Button>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-500">
+        領域 {regions.length} 件
+        {addMode ? " · 次のドラッグで領域を追加します" : " · ドラッグで領域を置き換え"}
+      </p>
+    </div>
+  );
+}

--- a/src/features/field/ocr/image-crop.ts
+++ b/src/features/field/ocr/image-crop.ts
@@ -1,0 +1,50 @@
+import type { NormalizedOcrRegion } from "@/features/field/ocr/region-types";
+import { clampRegion } from "@/features/field/ocr/region-types";
+
+export async function loadImageBitmapFromFile(file: File): Promise<ImageBitmap> {
+  return createImageBitmap(file, { imageOrientation: "from-image" });
+}
+
+export function cropRegionFromBitmap(
+  bitmap: ImageBitmap,
+  region: NormalizedOcrRegion,
+): HTMLCanvasElement {
+  const clamped = clampRegion(region);
+  const sx = Math.round(clamped.x * bitmap.width);
+  const sy = Math.round(clamped.y * bitmap.height);
+  const sw = Math.max(1, Math.round(clamped.w * bitmap.width));
+  const sh = Math.max(1, Math.round(clamped.h * bitmap.height));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = sw;
+  canvas.height = sh;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas が利用できません");
+  }
+
+  ctx.drawImage(bitmap, sx, sy, sw, sh, 0, 0, sw, sh);
+  return canvas;
+}
+
+export async function cropRegionToBlob(
+  bitmap: ImageBitmap,
+  region: NormalizedOcrRegion,
+  mimeType = "image/png",
+): Promise<Blob> {
+  const canvas = cropRegionFromBitmap(bitmap, region);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+          return;
+        }
+        reject(new Error("切り出し画像の生成に失敗しました"));
+      },
+      mimeType,
+      0.92,
+    );
+  });
+}

--- a/src/features/field/ocr/region-types.ts
+++ b/src/features/field/ocr/region-types.ts
@@ -1,0 +1,115 @@
+import type { CSSProperties } from "react";
+import type { OcrRegion } from "@/server/api/schemas/scan";
+
+export type NormalizedOcrRegion = OcrRegion;
+
+/** Suggested default ROI (centered, leaves margins for captions/background). */
+export const DEFAULT_OCR_REGION: NormalizedOcrRegion = {
+  x: 0.075,
+  y: 0.1,
+  w: 0.85,
+  h: 0.75,
+};
+
+export type DisplayedImageLayout = {
+  offsetX: number;
+  offsetY: number;
+  displayWidth: number;
+  displayHeight: number;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+export function getDisplayedImageLayout(
+  containerWidth: number,
+  containerHeight: number,
+  naturalWidth: number,
+  naturalHeight: number,
+): DisplayedImageLayout {
+  if (naturalWidth <= 0 || naturalHeight <= 0 || containerWidth <= 0) {
+    return {
+      offsetX: 0,
+      offsetY: 0,
+      displayWidth: containerWidth,
+      displayHeight: containerHeight,
+      containerWidth,
+      containerHeight,
+    };
+  }
+
+  const scale = Math.min(
+    containerWidth / naturalWidth,
+    containerHeight / naturalHeight,
+  );
+  const displayWidth = naturalWidth * scale;
+  const displayHeight = naturalHeight * scale;
+
+  return {
+    offsetX: (containerWidth - displayWidth) / 2,
+    offsetY: (containerHeight - displayHeight) / 2,
+    displayWidth,
+    displayHeight,
+    containerWidth,
+    containerHeight,
+  };
+}
+
+export function clientPointToNormalized(
+  clientX: number,
+  clientY: number,
+  containerRect: DOMRect,
+  layout: DisplayedImageLayout,
+): { x: number; y: number } | null {
+  const localX = clientX - containerRect.left - layout.offsetX;
+  const localY = clientY - containerRect.top - layout.offsetY;
+
+  if (
+    localX < 0 ||
+    localY < 0 ||
+    localX > layout.displayWidth ||
+    localY > layout.displayHeight
+  ) {
+    return null;
+  }
+
+  return {
+    x: localX / layout.displayWidth,
+    y: localY / layout.displayHeight,
+  };
+}
+
+export function normalizedRectFromPoints(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): NormalizedOcrRegion | null {
+  const x = Math.min(start.x, end.x);
+  const y = Math.min(start.y, end.y);
+  const w = Math.abs(end.x - start.x);
+  const h = Math.abs(end.y - start.y);
+
+  if (w < 0.03 || h < 0.03) {
+    return null;
+  }
+
+  return clampRegion({ x, y, w, h });
+}
+
+export function clampRegion(region: NormalizedOcrRegion): NormalizedOcrRegion {
+  const x = Math.max(0, Math.min(1, region.x));
+  const y = Math.max(0, Math.min(1, region.y));
+  const w = Math.max(0.01, Math.min(1 - x, region.w));
+  const h = Math.max(0.01, Math.min(1 - y, region.h));
+  return { x, y, w, h };
+}
+
+export function regionToOverlayStyle(
+  region: NormalizedOcrRegion,
+  layout: DisplayedImageLayout,
+): CSSProperties {
+  return {
+    left: layout.offsetX + region.x * layout.displayWidth,
+    top: layout.offsetY + region.y * layout.displayHeight,
+    width: region.w * layout.displayWidth,
+    height: region.h * layout.displayHeight,
+  };
+}

--- a/src/features/field/ocr/tesseract-client.ts
+++ b/src/features/field/ocr/tesseract-client.ts
@@ -7,7 +7,24 @@ export type OcrResult = {
   ocrMetadata: OcrMetadata;
 };
 
-export type OcrProgressHandler = (progress: number) => void;
+export type OcrProgressUpdate = {
+  progress: number;
+  status: string;
+};
+
+export type OcrProgressHandler = (update: OcrProgressUpdate) => void;
+
+const OCR_STATUS_LABELS: Record<string, string> = {
+  "loading tesseract core": "OCR エンジンを読み込み中",
+  "initializing tesseract": "OCR を初期化中",
+  "loading language traineddata": "言語データを読み込み中",
+  "initializing api": "OCR API を初期化中",
+  "recognizing text": "文字を認識中",
+};
+
+export function getOcrStatusLabel(status: string): string {
+  return OCR_STATUS_LABELS[status] ?? "OCR を準備中";
+}
 
 export async function runOcr(
   imageSource: string | File,
@@ -17,9 +34,10 @@ export async function runOcr(
   const { createWorker } = await import("tesseract.js");
   const worker = await createWorker(language, 1, {
     logger: (message) => {
-      if (message.status === "recognizing text") {
-        onProgress?.(message.progress);
-      }
+      onProgress?.({
+        progress: message.progress ?? 0,
+        status: message.status,
+      });
     },
   });
 
@@ -39,19 +57,4 @@ export async function runOcr(
   } finally {
     await worker.terminate();
   }
-}
-
-export function readFileAsDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result === "string") {
-        resolve(reader.result);
-        return;
-      }
-      reject(new Error("画像の読み込みに失敗しました"));
-    };
-    reader.onerror = () => reject(new Error("画像の読み込みに失敗しました"));
-    reader.readAsDataURL(file);
-  });
 }

--- a/src/features/field/ocr/tesseract-client.ts
+++ b/src/features/field/ocr/tesseract-client.ts
@@ -1,0 +1,57 @@
+import type { OcrMetadata } from "@/server/api/schemas/scan";
+
+export type OcrLanguage = "jpn" | "jpn_vert" | "eng";
+
+export type OcrResult = {
+  plainText: string;
+  ocrMetadata: OcrMetadata;
+};
+
+export type OcrProgressHandler = (progress: number) => void;
+
+export async function runOcr(
+  imageSource: string | File,
+  language: OcrLanguage = "jpn",
+  onProgress?: OcrProgressHandler,
+): Promise<OcrResult> {
+  const { createWorker } = await import("tesseract.js");
+  const worker = await createWorker(language, 1, {
+    logger: (message) => {
+      if (message.status === "recognizing text") {
+        onProgress?.(message.progress);
+      }
+    },
+  });
+
+  try {
+    const { data } = await worker.recognize(imageSource);
+    const plainText = data.text.trim();
+
+    return {
+      plainText,
+      ocrMetadata: {
+        engine: "tesseract.js",
+        language,
+        confidence: data.confidence,
+        processedAt: new Date().toISOString(),
+      },
+    };
+  } finally {
+    await worker.terminate();
+  }
+}
+
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error("画像の読み込みに失敗しました"));
+    };
+    reader.onerror = () => reject(new Error("画像の読み込みに失敗しました"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/features/field/ocr/tesseract-client.ts
+++ b/src/features/field/ocr/tesseract-client.ts
@@ -1,4 +1,12 @@
 import type { OcrMetadata } from "@/server/api/schemas/scan";
+import {
+  cropRegionToBlob,
+  loadImageBitmapFromFile,
+} from "@/features/field/ocr/image-crop";
+import {
+  DEFAULT_OCR_REGION,
+  type NormalizedOcrRegion,
+} from "@/features/field/ocr/region-types";
 
 export type OcrLanguage = "jpn" | "jpn_vert" | "eng";
 
@@ -10,6 +18,8 @@ export type OcrResult = {
 export type OcrProgressUpdate = {
   progress: number;
   status: string;
+  regionIndex?: number;
+  regionCount?: number;
 };
 
 export type OcrProgressHandler = (update: OcrProgressUpdate) => void;
@@ -22,12 +32,16 @@ const OCR_STATUS_LABELS: Record<string, string> = {
   "recognizing text": "文字を認識中",
 };
 
-export function getOcrStatusLabel(status: string): string {
-  return OCR_STATUS_LABELS[status] ?? "OCR を準備中";
+export function getOcrStatusLabel(update: OcrProgressUpdate): string {
+  const base = OCR_STATUS_LABELS[update.status] ?? "OCR を準備中";
+  if (update.regionIndex != null && update.regionCount != null) {
+    return `${base}（領域 ${update.regionIndex + 1}/${update.regionCount}）`;
+  }
+  return base;
 }
 
 export async function runOcr(
-  imageSource: string | File,
+  imageSource: string | File | Blob,
   language: OcrLanguage = "jpn",
   onProgress?: OcrProgressHandler,
 ): Promise<OcrResult> {
@@ -56,5 +70,67 @@ export async function runOcr(
     };
   } finally {
     await worker.terminate();
+  }
+}
+
+export async function runOcrOnRegions(
+  file: File,
+  regions: NormalizedOcrRegion[],
+  language: OcrLanguage = "jpn",
+  onProgress?: OcrProgressHandler,
+): Promise<OcrResult> {
+  const effectiveRegions =
+    regions.length > 0 ? regions : [DEFAULT_OCR_REGION];
+
+  const bitmap = await loadImageBitmapFromFile(file);
+  const { createWorker } = await import("tesseract.js");
+  const worker = await createWorker(language, 1, {
+    logger: (message) => {
+      onProgress?.({
+        progress: message.progress ?? 0,
+        status: message.status,
+      });
+    },
+  });
+
+  try {
+    const textParts: string[] = [];
+    let confidenceSum = 0;
+    let recognizedCount = 0;
+
+    for (let index = 0; index < effectiveRegions.length; index++) {
+      const region = effectiveRegions[index]!;
+      onProgress?.({
+        progress: 0,
+        status: "recognizing text",
+        regionIndex: index,
+        regionCount: effectiveRegions.length,
+      });
+
+      const blob = await cropRegionToBlob(bitmap, region);
+      const { data } = await worker.recognize(blob);
+
+      const text = data.text.trim();
+      if (text) {
+        textParts.push(text);
+      }
+      confidenceSum += data.confidence;
+      recognizedCount += 1;
+    }
+
+    return {
+      plainText: textParts.join("\n\n"),
+      ocrMetadata: {
+        engine: "tesseract.js",
+        language,
+        confidence:
+          recognizedCount > 0 ? confidenceSum / recognizedCount : undefined,
+        regions: effectiveRegions,
+        processedAt: new Date().toISOString(),
+      },
+    };
+  } finally {
+    await worker.terminate();
+    bitmap.close();
   }
 }

--- a/src/server/api/routers/scan.ts
+++ b/src/server/api/routers/scan.ts
@@ -1,11 +1,36 @@
+import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { CreateFromScanInputSchema } from "@/server/api/schemas/scan";
 import { createFromScan } from "@/server/services/scan/create-from-scan.service";
+import { listScanSessions } from "@/server/services/scan/list-scan-sessions.service";
+import { getScanSession } from "@/server/services/scan/get-scan-session.service";
 
 export const scanRouter = createTRPCRouter({
   createFromScan: protectedProcedure
     .input(CreateFromScanInputSchema)
     .mutation(async ({ ctx, input }) => {
       return createFromScan(ctx, input);
+    }),
+
+  listSessions: protectedProcedure
+    .input(
+      z
+        .object({
+          limit: z.number().int().min(1).max(100).default(30),
+          page: z.number().int().min(1).default(1),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      return listScanSessions(ctx, {
+        limit: input?.limit ?? 30,
+        page: input?.page ?? 1,
+      });
+    }),
+
+  getSession: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return getScanSession(ctx, input.id);
     }),
 });

--- a/src/server/api/schemas/scan.ts
+++ b/src/server/api/schemas/scan.ts
@@ -13,6 +13,9 @@ export const CreateFromScanInputSchema = z.object({
   name: z.string().min(1),
   plainText: z.string().min(1),
   ocrMetadata: OcrMetadataSchema.optional(),
+  /** Pre-uploaded scan image URL (preferred — avoids large tRPC payloads). */
+  sourceImageUrl: z.string().url().optional(),
+  /** @deprecated Prefer uploading client-side and passing sourceImageUrl. */
   imageDataUrl: z.string().optional(),
   topicSpaceId: z.string().optional(),
 });

--- a/src/server/api/schemas/scan.ts
+++ b/src/server/api/schemas/scan.ts
@@ -1,11 +1,19 @@
 import { z } from "zod";
 
+export const OcrRegionSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  w: z.number().min(0).max(1),
+  h: z.number().min(0).max(1),
+});
+
 export const OcrMetadataSchema = z
   .object({
     engine: z.string().optional(),
     language: z.string().optional(),
     confidence: z.number().optional(),
     processedAt: z.string().optional(),
+    regions: z.array(OcrRegionSchema).optional(),
   })
   .catchall(z.unknown());
 
@@ -37,6 +45,7 @@ export const PublishedNodeMatchSchema = z.object({
 });
 
 export type OcrMetadata = z.infer<typeof OcrMetadataSchema>;
+export type OcrRegion = z.infer<typeof OcrRegionSchema>;
 export type CreateFromScanInput = z.infer<typeof CreateFromScanInputSchema>;
 export type SearchPublishedNodesInput = z.infer<
   typeof SearchPublishedNodesInputSchema

--- a/src/server/services/scan/create-from-scan.service.ts
+++ b/src/server/services/scan/create-from-scan.service.ts
@@ -37,7 +37,9 @@ export async function createFromScan(
   }
 
   let sourceImageUrl: string | null = null;
-  if (input.imageDataUrl) {
+  if (input.sourceImageUrl) {
+    sourceImageUrl = input.sourceImageUrl;
+  } else if (input.imageDataUrl) {
     sourceImageUrl = await storageUtils.uploadFromDataURL(
       input.imageDataUrl,
       BUCKETS.PATH_TO_INPUT_SCAN,

--- a/src/server/services/scan/get-scan-session.service.ts
+++ b/src/server/services/scan/get-scan-session.service.ts
@@ -38,7 +38,7 @@ export async function getScanSession(
 
   const graphRecord = formDocumentGraphForFrontend(
     document.graph,
-    ctx.session.user.preferredLocale as LocaleEnum,
+    (ctx.session.user.preferredLocale ?? "ja") as LocaleEnum,
   );
   const plainText = await getTextFromDocumentFile(
     document.url,

--- a/src/server/services/scan/get-scan-session.service.ts
+++ b/src/server/services/scan/get-scan-session.service.ts
@@ -1,0 +1,64 @@
+import type { PrismaClient } from "@prisma/client";
+import { DocumentType } from "@prisma/client";
+import { formDocumentGraphForFrontend } from "@/app/_utils/kg/frontend-properties";
+import { getTextFromDocumentFile } from "@/app/_utils/text/text";
+import type { LocaleEnum } from "@/app/const/types";
+import type { OcrMetadata } from "@/server/api/schemas/scan";
+import { searchPublishedNodesByNames } from "@/server/services/workspace/search-published-nodes.service";
+
+type GetScanSessionCtx = {
+  db: PrismaClient;
+  session: { user: { id: string; preferredLocale?: string | null } };
+};
+
+export async function getScanSession(
+  ctx: GetScanSessionCtx,
+  sourceDocumentId: string,
+) {
+  const document = await ctx.db.sourceDocument.findFirst({
+    where: {
+      id: sourceDocumentId,
+      userId: ctx.session.user.id,
+      isDeleted: false,
+      documentType: DocumentType.INPUT_SCAN,
+    },
+    include: {
+      graph: {
+        include: {
+          graphNodes: true,
+          graphRelationships: true,
+        },
+      },
+    },
+  });
+
+  if (!document?.graph) {
+    throw new Error("スキャンセッションが見つかりません");
+  }
+
+  const graphRecord = formDocumentGraphForFrontend(
+    document.graph,
+    ctx.session.user.preferredLocale as LocaleEnum,
+  );
+  const plainText = await getTextFromDocumentFile(
+    document.url,
+    document.documentType,
+  );
+  const matchCandidates = await searchPublishedNodesByNames(
+    ctx,
+    graphRecord.dataJson.nodes.map((node) => node.name),
+    20,
+  );
+
+  return {
+    id: document.id,
+    name: document.name,
+    createdAt: document.createdAt,
+    sourceImageUrl: document.sourceImageUrl,
+    ocrMetadata: document.ocrMetadata as OcrMetadata | null,
+    plainText,
+    graph: graphRecord.dataJson,
+    graphId: document.graph.id,
+    matchCandidates,
+  };
+}

--- a/src/server/services/scan/list-scan-sessions.service.ts
+++ b/src/server/services/scan/list-scan-sessions.service.ts
@@ -1,0 +1,50 @@
+import { DocumentType, type PrismaClient } from "@prisma/client";
+
+type ListScanSessionsCtx = {
+  db: PrismaClient;
+  session: { user: { id: string } };
+};
+
+export async function listScanSessions(
+  ctx: ListScanSessionsCtx,
+  input: { limit: number; page: number },
+) {
+  const skip = (input.page - 1) * input.limit;
+  const where = {
+    userId: ctx.session.user.id,
+    isDeleted: false,
+    documentType: DocumentType.INPUT_SCAN,
+  };
+
+  const [items, totalCount] = await Promise.all([
+    ctx.db.sourceDocument.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      include: {
+        graph: {
+          select: {
+            id: true,
+            graphNodes: { select: { id: true } },
+          },
+        },
+      },
+      take: input.limit,
+      skip,
+    }),
+    ctx.db.sourceDocument.count({ where }),
+  ]);
+
+  return {
+    items: items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      createdAt: item.createdAt,
+      sourceImageUrl: item.sourceImageUrl,
+      graphId: item.graph?.id ?? null,
+      nodeCount: item.graph?.graphNodes.length ?? 0,
+    })),
+    totalCount,
+    totalPages: Math.ceil(totalCount / input.limit),
+    currentPage: input.page,
+  };
+}


### PR DESCRIPTION
## Summary

- Phase 1 API（`scan.createFromScan` 等）を使うモバイル向けフィールドリサーチ UI を追加
- `/field`（セッション一覧）、`/field/scan`（撮影→OCR→グラフ作成）、`/field/scan/[id]`（結果・公開ノード照合）を実装
- クライアント OCR に `tesseract.js`（`jpn` / `jpn_vert` / `eng`）を導入
- `scan.listSessions` / `scan.getSession` API を追加し、SPGuard で `/field` をスマホ許可ページに設定

**Depends on:** #56（Phase 1）

## Test plan

- [ ] `npm run dev` で `/field` にアクセスし、未ログイン時に Google ログイン導線が表示される
- [ ] ログイン後 `/field/scan` で画像選択 → OCR → テキスト編集 → 「グラフを作成」が成功する
- [ ] `/field/scan/[id]` で OCR テキスト、グラフ概要、公開ノード一致候補が表示される
- [ ] 公開ノード検索（2文字以上）で `workspace.searchPublishedNodes` の結果が表示される
- [ ] スマホ画面幅で SPGuard ブロックが出ず `/field` 以下が利用できる
- [ ] `SKIP_ENV_VALIDATION=true npm run build` が通る


Made with [Cursor](https://cursor.com)