### PR TITLE
fix: address PR #59 Gemini Code Assist review feedback

### DIFF
--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -323,7 +323,6 @@ export function FieldScanFlow() {
       setErrorMessage(
         error instanceof Error ? error.message : "グラフ作成に失敗しました",
       );
-    } finally {
       setIsSubmitting(false);
     }
   };

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -66,14 +66,7 @@ export function FieldScanFlow() {
   const [pipelineStage, setPipelineStage] = useState<PipelineStage>(null);
   const [pipelineProgress, setPipelineProgress] = useState(0);
 
-  const createFromScan = api.scan.createFromScan.useMutation({
-    onSuccess: (result) => {
-      router.push(`/field/scan/${result.sourceDocument.id}`);
-    },
-    onError: (error) => {
-      setErrorMessage(error.message ?? "グラフ作成に失敗しました");
-    },
-  });
+  const createFromScan = api.scan.createFromScan.useMutation();
   const normalizeOcrText = api.scan.normalizeOcrText.useMutation();
   const extractGraphFromPlainText = api.kg.extractKGFromPlainText.useMutation();
   const previewMatchNodeNames = useMemo(
@@ -311,7 +304,7 @@ export function FieldScanFlow() {
         sourceImageUrl = uploadedUrl;
       }
 
-      await createFromScan.mutateAsync({
+      const result = await createFromScan.mutateAsync({
         name: sessionName.trim(),
         plainText: trimmedPlainText,
         graphDocument: graphPreview ?? undefined,
@@ -319,6 +312,8 @@ export function FieldScanFlow() {
         sourceImageUrl,
         ocrMetadata,
       });
+
+      router.push(`/field/scan/${result.sourceDocument.id}`);
     } catch (error) {
       setErrorMessage(
         error instanceof Error ? error.message : "グラフ作成に失敗しました",

--- a/src/features/field/ocr/tesseract-client.ts
+++ b/src/features/field/ocr/tesseract-client.ts
@@ -83,54 +83,57 @@ export async function runOcrOnRegions(
     regions.length > 0 ? regions : [DEFAULT_OCR_REGION];
 
   const bitmap = await loadImageBitmapFromFile(file);
-  const { createWorker } = await import("tesseract.js");
-  const worker = await createWorker(language, 1, {
-    logger: (message) => {
-      onProgress?.({
-        progress: message.progress ?? 0,
-        status: message.status,
-      });
-    },
-  });
-
   try {
-    const textParts: string[] = [];
-    let confidenceSum = 0;
-    let recognizedCount = 0;
-
-    for (let index = 0; index < effectiveRegions.length; index++) {
-      const region = effectiveRegions[index]!;
-      onProgress?.({
-        progress: 0,
-        status: "recognizing text",
-        regionIndex: index,
-        regionCount: effectiveRegions.length,
-      });
-
-      const blob = await cropRegionToBlob(bitmap, region);
-      const { data } = await worker.recognize(blob);
-
-      const text = data.text.trim();
-      if (text) {
-        textParts.push(text);
-      }
-      confidenceSum += data.confidence;
-      recognizedCount += 1;
-    }
-
-    return {
-      plainText: textParts.join("\n\n"),
-      ocrMetadata: {
-        engine: "tesseract.js",
-        language,
-        confidence:
-          recognizedCount > 0 ? confidenceSum / recognizedCount : undefined,
-        regions: effectiveRegions,
-        processedAt: new Date().toISOString(),
+    const { createWorker } = await import("tesseract.js");
+    const worker = await createWorker(language, 1, {
+      logger: (message) => {
+        onProgress?.({
+          progress: message.progress ?? 0,
+          status: message.status,
+        });
       },
-    };
+    });
+
+    try {
+      const textParts: string[] = [];
+      let confidenceSum = 0;
+      let recognizedCount = 0;
+
+      for (let index = 0; index < effectiveRegions.length; index++) {
+        const region = effectiveRegions[index]!;
+        onProgress?.({
+          progress: 0,
+          status: "recognizing text",
+          regionIndex: index,
+          regionCount: effectiveRegions.length,
+        });
+
+        const blob = await cropRegionToBlob(bitmap, region);
+        const { data } = await worker.recognize(blob);
+
+        const text = data.text.trim();
+        if (text) {
+          textParts.push(text);
+        }
+        confidenceSum += data.confidence;
+        recognizedCount += 1;
+      }
+
+      return {
+        plainText: textParts.join("\n\n"),
+        ocrMetadata: {
+          engine: "tesseract.js",
+          language,
+          confidence:
+            recognizedCount > 0 ? confidenceSum / recognizedCount : undefined,
+          regions: effectiveRegions,
+          processedAt: new Date().toISOString(),
+        },
+      };
+    } finally {
+      await worker.terminate();
+    }
   } finally {
-    await worker.terminate();
     bitmap.close();
   }
 }

--- a/src/server/services/scan/search-user-scan-node-matches.service.ts
+++ b/src/server/services/scan/search-user-scan-node-matches.service.ts
@@ -20,10 +20,12 @@ export async function searchUserScanNodeMatchesByNames(
   const nodes = await ctx.db.graphNode.findMany({
     where: {
       deletedAt: null,
-      name: {
-        in: uniqueNames,
-        mode: "insensitive",
-      },
+      OR: uniqueNames.map((name) => ({
+        name: {
+          equals: name,
+          mode: "insensitive" as const,
+        },
+      })),
       documentGraph: {
         sourceDocument: {
           userId: ctx.session.user.id,

--- a/src/server/services/workspace/search-published-nodes.service.ts
+++ b/src/server/services/workspace/search-published-nodes.service.ts
@@ -118,10 +118,12 @@ export async function searchPublishedNodesByNames(
   const nodes = await ctx.db.graphNode.findMany({
     where: {
       deletedAt: null,
-      name: {
-        in: uniqueNames,
-        mode: "insensitive",
-      },
+      OR: uniqueNames.map((name) => ({
+        name: {
+          equals: name,
+          mode: "insensitive" as const,
+        },
+      })),
       topicSpace: {
         referencedByWorkspaces: {
           some: publishedWorkspaceFilter(),


### PR DESCRIPTION
## Summary
- Prisma の `in` + `mode: "insensitive"` は非対応のため、`OR` + `equals` + `mode: "insensitive"` に変更（`search-user-scan-node-matches` / `search-published-nodes`）
- `runOcrOnRegions` で worker 初期化失敗時も `ImageBitmap` が必ず解放されるようネストした `try/finally` を追加
- 保存成功後のリダイレクト中に二重送信されないよう、`setIsSubmitting(false)` を `catch` のみに移動
- `gpt-5-nano` は動作確認済みのため変更なし

## Test plan
- [ ] グラフプレビューでノード一致ハイライト（Workspace / 他スキャン）が表示される
- [ ] スキャン保存成功後、リダイレクト中に保存ボタンが再度押せない
- [ ] 複数領域 OCR が正常に完了する（モバイルブラウザ含む）
- [ ] `npm run build` が成功する

Made with [Cursor](https://cursor.com)