### PR TITLE
feat: improve field scan camera capture quality

### DIFF
--- a/src/features/field/components/live-camera-scanner.tsx
+++ b/src/features/field/components/live-camera-scanner.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/app/_components/button/button";
 import { ChevronLeftIcon } from "@/app/_components/icons";
+import {
+  captureStillPhotoFromStream,
+  openCameraStreamWithFallback,
+  stopCameraStream,
+} from "@/features/field/ocr/camera-capture";
 
 type LiveCameraScannerProps = {
   onCapture: (file: File) => void;
@@ -16,14 +21,14 @@ export function LiveCameraScanner({
   onBack,
 }: LiveCameraScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const [isStarting, setIsStarting] = useState(true);
+  const [isCapturing, setIsCapturing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const canCapture = useMemo(
-    () => !isStarting && !errorMessage,
-    [isStarting, errorMessage],
+    () => !isStarting && !isCapturing && !errorMessage,
+    [isStarting, isCapturing, errorMessage],
   );
 
   useEffect(() => {
@@ -33,14 +38,9 @@ export function LiveCameraScanner({
       try {
         setIsStarting(true);
         setErrorMessage(null);
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            facingMode: { ideal: "environment" },
-          },
-          audio: false,
-        });
+        const stream = await openCameraStreamWithFallback();
         if (!isActive) {
-          stream.getTracks().forEach((track) => track.stop());
+          stopCameraStream(stream);
           return;
         }
 
@@ -64,38 +64,27 @@ export function LiveCameraScanner({
 
     return () => {
       isActive = false;
-      streamRef.current?.getTracks().forEach((track) => track.stop());
+      stopCameraStream(streamRef.current);
       streamRef.current = null;
     };
   }, []);
 
-  const handleCapture = () => {
+  const handleCapture = async () => {
     const video = videoRef.current;
-    const canvas = canvasRef.current;
-    if (!video || !canvas || !canCapture) return;
+    const stream = streamRef.current;
+    if (!video || !stream || !canCapture) return;
 
-    const width = video.videoWidth;
-    const height = video.videoHeight;
-    if (width <= 0 || height <= 0) return;
+    setIsCapturing(true);
+    setErrorMessage(null);
 
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    ctx.drawImage(video, 0, 0, width, height);
-    canvas.toBlob(
-      (blob) => {
-        if (!blob) return;
-        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-        const file = new File([blob], `scan-${timestamp}.jpg`, {
-          type: "image/jpeg",
-        });
-        onCapture(file);
-      },
-      "image/jpeg",
-      0.92,
-    );
+    try {
+      const file = await captureStillPhotoFromStream(stream, video);
+      onCapture(file);
+    } catch {
+      setErrorMessage("撮影に失敗しました。もう一度お試しください。");
+    } finally {
+      setIsCapturing(false);
+    }
   };
 
   return (
@@ -144,7 +133,7 @@ export function LiveCameraScanner({
           </Button>
           <button
             type="button"
-            onClick={handleCapture}
+            onClick={() => void handleCapture()}
             disabled={!canCapture}
             aria-label="撮影する"
             className="h-[4.5rem] w-[4.5rem] shrink-0 rounded-full border-4 border-white bg-orange-400 shadow-lg transition disabled:cursor-not-allowed disabled:opacity-50"
@@ -153,7 +142,6 @@ export function LiveCameraScanner({
         </div>
       </div>
 
-      <canvas ref={canvasRef} className="hidden" />
     </div>
   );
 }

--- a/src/features/field/components/live-camera-scanner.tsx
+++ b/src/features/field/components/live-camera-scanner.tsx
@@ -9,6 +9,9 @@ import {
   stopCameraStream,
 } from "@/features/field/ocr/camera-capture";
 
+const CAMERA_STARTUP_ERROR =
+  "カメラを起動できませんでした。ファイル選択から画像を追加してください。";
+
 type LiveCameraScannerProps = {
   onCapture: (file: File) => void;
   onOpenFilePicker: () => void;
@@ -27,7 +30,10 @@ export function LiveCameraScanner({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const canCapture = useMemo(
-    () => !isStarting && !isCapturing && !errorMessage,
+    () =>
+      !isStarting &&
+      !isCapturing &&
+      errorMessage !== CAMERA_STARTUP_ERROR,
     [isStarting, isCapturing, errorMessage],
   );
 
@@ -50,9 +56,7 @@ export function LiveCameraScanner({
           await videoRef.current.play();
         }
       } catch {
-        setErrorMessage(
-          "カメラを起動できませんでした。ファイル選択から画像を追加してください。",
-        );
+        setErrorMessage(CAMERA_STARTUP_ERROR);
       } finally {
         if (isActive) {
           setIsStarting(false);

--- a/src/features/field/ocr/camera-capture.ts
+++ b/src/features/field/ocr/camera-capture.ts
@@ -33,9 +33,16 @@ const CAMERA_CONSTRAINT_CANDIDATES: MediaStreamConstraints[] = [
   },
 ];
 
+function extensionForMimeType(mimeType: string): string {
+  if (mimeType === "image/png") return "png";
+  if (mimeType === "image/webp") return "webp";
+  return "jpg";
+}
+
 function createScanImageFile(blob: Blob, mimeType: string): File {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  return new File([blob], `scan-${timestamp}.jpg`, { type: mimeType });
+  const extension = extensionForMimeType(mimeType);
+  return new File([blob], `scan-${timestamp}.${extension}`, { type: mimeType });
 }
 
 function isImageCaptureSupported(): boolean {
@@ -159,6 +166,11 @@ export async function captureStillPhotoFromStream(
 
   if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
     await new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error("カメラ映像の準備がタイムアウトしました"));
+      }, 5000);
+
       const onReady = () => {
         cleanup();
         resolve();
@@ -168,6 +180,7 @@ export async function captureStillPhotoFromStream(
         reject(new Error("カメラ映像の準備に失敗しました"));
       };
       const cleanup = () => {
+        clearTimeout(timeoutId);
         video.removeEventListener("loadeddata", onReady);
         video.removeEventListener("error", onError);
       };

--- a/src/features/field/ocr/camera-capture.ts
+++ b/src/features/field/ocr/camera-capture.ts
@@ -1,0 +1,184 @@
+const JPEG_QUALITY = 0.95;
+
+const CAMERA_CONSTRAINT_CANDIDATES: MediaStreamConstraints[] = [
+  {
+    video: {
+      facingMode: { ideal: "environment" },
+      width: { ideal: 3840 },
+      height: { ideal: 2160 },
+    },
+    audio: false,
+  },
+  {
+    video: {
+      facingMode: { ideal: "environment" },
+      width: { ideal: 1920 },
+      height: { ideal: 1080 },
+    },
+    audio: false,
+  },
+  {
+    video: {
+      facingMode: { ideal: "environment" },
+      width: { ideal: 1280 },
+      height: { ideal: 720 },
+    },
+    audio: false,
+  },
+  {
+    video: {
+      facingMode: { ideal: "environment" },
+    },
+    audio: false,
+  },
+];
+
+function createScanImageFile(blob: Blob, mimeType: string): File {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return new File([blob], `scan-${timestamp}.jpg`, { type: mimeType });
+}
+
+function isImageCaptureSupported(): boolean {
+  return typeof ImageCapture !== "undefined";
+}
+
+async function applyMaxStreamConstraints(track: MediaStreamTrack): Promise<void> {
+  const capabilities = track.getCapabilities?.();
+  if (!capabilities) return;
+
+  const width = capabilities.width;
+  const height = capabilities.height;
+  if (!width?.max && !height?.max) return;
+
+  try {
+    await track.applyConstraints({
+      width: width?.max ? { ideal: width.max } : undefined,
+      height: height?.max ? { ideal: height.max } : undefined,
+    });
+  } catch {
+    // Device may reject max constraints; keep negotiated stream.
+  }
+}
+
+export async function openCameraStreamWithFallback(): Promise<MediaStream> {
+  let lastError: unknown;
+
+  for (const constraints of CAMERA_CONSTRAINT_CANDIDATES) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const track = stream.getVideoTracks()[0];
+      if (track) {
+        await applyMaxStreamConstraints(track);
+      }
+      return stream;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("カメラを起動できませんでした");
+}
+
+async function captureWithImageCapture(
+  track: MediaStreamTrack,
+): Promise<File | null> {
+  if (!isImageCaptureSupported()) return null;
+
+  try {
+    const imageCapture = new ImageCapture(track);
+    const settings: PhotoSettings = {};
+
+    if (typeof imageCapture.getPhotoCapabilities === "function") {
+      const capabilities = await imageCapture.getPhotoCapabilities();
+      if (capabilities.imageWidth?.max) {
+        settings.imageWidth = capabilities.imageWidth.max;
+      }
+      if (capabilities.imageHeight?.max) {
+        settings.imageHeight = capabilities.imageHeight.max;
+      }
+    }
+
+    const blob = await imageCapture.takePhoto(
+      Object.keys(settings).length > 0 ? settings : undefined,
+    );
+    const mimeType = blob.type || "image/jpeg";
+    return createScanImageFile(blob, mimeType);
+  } catch {
+    return null;
+  }
+}
+
+function captureFromVideoElement(video: HTMLVideoElement): Promise<File> {
+  const width = video.videoWidth;
+  const height = video.videoHeight;
+  if (width <= 0 || height <= 0) {
+    return Promise.reject(new Error("カメラ映像の解像度を取得できませんでした"));
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return Promise.reject(new Error("Canvas が利用できません"));
+  }
+
+  ctx.drawImage(video, 0, 0, width, height);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("撮影画像の生成に失敗しました"));
+          return;
+        }
+        resolve(createScanImageFile(blob, "image/jpeg"));
+      },
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  });
+}
+
+/**
+ * Prefer high-resolution still capture (ImageCapture API), then fall back to
+ * grabbing a frame from the live preview video element.
+ */
+export async function captureStillPhotoFromStream(
+  stream: MediaStream,
+  video: HTMLVideoElement,
+): Promise<File> {
+  const track = stream.getVideoTracks()[0];
+  if (track) {
+    const still = await captureWithImageCapture(track);
+    if (still) return still;
+  }
+
+  if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+    await new Promise<void>((resolve, reject) => {
+      const onReady = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        reject(new Error("カメラ映像の準備に失敗しました"));
+      };
+      const cleanup = () => {
+        video.removeEventListener("loadeddata", onReady);
+        video.removeEventListener("error", onError);
+      };
+      video.addEventListener("loadeddata", onReady, { once: true });
+      video.addEventListener("error", onError, { once: true });
+    });
+  }
+
+  return captureFromVideoElement(video);
+}
+
+export function stopCameraStream(stream: MediaStream | null): void {
+  stream?.getTracks().forEach((track) => track.stop());
+}


### PR DESCRIPTION
## Summary
- Add `camera-capture.ts` with stepped `getUserMedia` resolution fallbacks and max stream constraints when supported
- Prefer `ImageCapture.takePhoto()` at maximum photo resolution on capable devices (e.g. iOS Safari 16+)
- Fall back to video-frame canvas capture at negotiated stream resolution for unsupported browsers

## Test plan
- [ ] iPhone: live scan capture is sharper than before; preview still works
- [ ] Desktop Chrome/Safari: capture succeeds via ImageCapture or fallback
- [ ] Older/unsupported browser: fallback capture still works
- [ ] 「ファイルから追加」 flow unchanged

Made with [Cursor](https://cursor.com)