### PR TITLE
feat(field): グラフ編集UI・スキャン一致検索・ドキュメント本文取得の修正

### DIFF
--- a/src/app/_components/input/text-input.tsx
+++ b/src/app/_components/input/text-input.tsx
@@ -6,7 +6,7 @@ export const TextInput = ({
   value,
   onChange,
   placeholder = "",
-  defaultValue = "",
+  defaultValue,
   autoFocus = false,
   required = false,
 }: {
@@ -18,6 +18,8 @@ export const TextInput = ({
   autoFocus?: boolean;
   required?: boolean;
 }) => {
+  const isControlled = value !== undefined;
+
   return (
     <Input
       type="text"
@@ -28,8 +30,9 @@ export const TextInput = ({
         "block w-full rounded-lg border-none bg-white/5 px-3 py-1.5 text-sm/6",
         "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
       )}
-      value={value}
-      defaultValue={defaultValue}
+      {...(isControlled
+        ? { value }
+        : { defaultValue: defaultValue ?? "" })}
       onChange={(e) => onChange(e.target.value)}
       required={required}
     />

--- a/src/app/_utils/sys/file.ts
+++ b/src/app/_utils/sys/file.ts
@@ -3,6 +3,7 @@ import { env } from "@/env";
 import { fileTypeFromBuffer } from "file-type";
 
 export const writeFile = (base64: string, name: string) => {
+  fs.mkdirSync(env.TMP_DIRECTORY, { recursive: true });
   const path = `${env.TMP_DIRECTORY}/${new Date().getTime()}_${name}`;
   const bin = atob(base64.replace(/^.*,/, ""));
   const buffer = new Uint8Array(bin.length);
@@ -14,8 +15,8 @@ export const writeFile = (base64: string, name: string) => {
     fs.writeFileSync(path, Buffer.from(buffer));
     return path;
   } catch (e) {
-    console.log("failed to write file");
-    return "";
+    console.error("failed to write file", e);
+    throw new Error("一時ファイルの書き込みに失敗しました");
   }
 };
 
@@ -25,13 +26,18 @@ export const exportJson = (jsonString: string, name: string) => {
 };
 
 export const writeLocalFileFromUrl = async (url: string, fileName: string) => {
-  const response = await fetch(url);
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) {
+    throw new Error("ファイル URL が空です");
+  }
+
+  const response = await fetch(trimmedUrl);
+  if (!response.ok) {
+    throw new Error(`ファイルの取得に失敗しました (${response.status})`);
+  }
+
   const fileBuffer = await response.arrayBuffer();
-  const localFilePath = writeFile(
-    Buffer.from(fileBuffer).toString("base64"),
-    fileName,
-  );
-  return localFilePath;
+  return writeFile(Buffer.from(fileBuffer).toString("base64"), fileName);
 };
 
 export type DocFileType = "pdf" | "docx" | "doc" | "txt" | undefined;

--- a/src/app/_utils/text/text-inspector.ts
+++ b/src/app/_utils/text/text-inspector.ts
@@ -20,7 +20,7 @@ const extractTextFromPDF = async (filePath: string): Promise<string[]> => {
   try {
     // pdf-parseを使用（より高精度なテキスト抽出）
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const pdfParse = require("pdf-parse") as PDFParseFunction;
+    const pdfParse = require("pdf-parse/lib/pdf-parse.js") as PDFParseFunction;
     const dataBuffer = fs.readFileSync(filePath);
     const pdfData = await pdfParse(dataBuffer);
 

--- a/src/app/_utils/text/text.ts
+++ b/src/app/_utils/text/text.ts
@@ -14,7 +14,7 @@ async function extractPdfTextFromLocalFile(filePath: string): Promise<string> {
   const pdfParse = require("pdf-parse/lib/pdf-parse.js") as (
     buffer: Buffer,
   ) => Promise<PdfParseResult>;
-  const dataBuffer = fs.readFileSync(filePath);
+  const dataBuffer = await fs.promises.readFile(filePath);
   const pdfData = await pdfParse(dataBuffer);
   return pdfData.text.trim();
 }

--- a/src/app/_utils/text/text.ts
+++ b/src/app/_utils/text/text.ts
@@ -1,25 +1,47 @@
+import fs from "fs";
+import { createRequire } from "module";
 import { DocumentType } from "@prisma/client";
 import { isFetchableStoragePublicUrl } from "../supabase/storage-url";
 import { writeLocalFileFromUrl } from "../sys/file";
-import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
 import { BUCKETS } from "../supabase/const";
+
+const require = createRequire(import.meta.url);
+
+type PdfParseResult = { text: string };
+
+async function extractPdfTextFromLocalFile(filePath: string): Promise<string> {
+  // index.js runs a debug read when `!module.parent` (true under createRequire).
+  const pdfParse = require("pdf-parse/lib/pdf-parse.js") as (
+    buffer: Buffer,
+  ) => Promise<PdfParseResult>;
+  const dataBuffer = fs.readFileSync(filePath);
+  const pdfData = await pdfParse(dataBuffer);
+  return pdfData.text.trim();
+}
 
 export const getTextFromDocumentFile = async (
   url: string,
   type: DocumentType,
 ) => {
-  if (type === DocumentType.INPUT_PDF) {
-    const localFilePath = await writeLocalFileFromUrl(url, "input.pdf");
-    const loader = new PDFLoader(localFilePath);
-    const documents = await loader.load();
-    return documents.map((doc) => doc.pageContent).join("\n");
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) {
+    throw new Error("ドキュメント URL が空です");
   }
 
-  if (!isFetchableStoragePublicUrl(url, BUCKETS.PATH_TO_INPUT_TXT)) {
+  if (type === DocumentType.INPUT_PDF) {
+    const localFilePath = await writeLocalFileFromUrl(trimmedUrl, "input.pdf");
+    return extractPdfTextFromLocalFile(localFilePath);
+  }
+
+  if (type !== DocumentType.INPUT_TXT && type !== DocumentType.INPUT_SCAN) {
+    throw new Error(`未対応のドキュメントタイプです: ${String(type)}`);
+  }
+
+  if (!isFetchableStoragePublicUrl(trimmedUrl, BUCKETS.PATH_TO_INPUT_TXT)) {
     throw new Error("ドキュメント本文の取得に失敗しました");
   }
 
-  const response = await fetch(url);
+  const response = await fetch(trimmedUrl);
   const text = await response.text();
 
   if (

--- a/src/features/field/components/field-scan-detail.tsx
+++ b/src/features/field/components/field-scan-detail.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  GraphDocumentForFrontend,
+  LocaleEnum,
+  NodeTypeForFrontend,
+} from "@/app/const/types";
 import dayjs from "dayjs";
 import { api } from "@/trpc/react";
 import { Button } from "@/app/_components/button/button";
@@ -21,14 +27,86 @@ type FieldScanDetailProps = {
   sessionId: string;
 };
 
+function normalizePropertiesToString(
+  properties: Record<string, string | number | boolean | null> | undefined,
+): Record<string, string> {
+  if (!properties) return {};
+  return Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => [key, String(value ?? "")]),
+  );
+}
+
+function syncNodeNameWithLocaleProperties(
+  node: NodeTypeForFrontend,
+  locale: LocaleEnum,
+): NodeTypeForFrontend {
+  const properties = normalizePropertiesToString(node.properties);
+  properties[`name_${locale}`] = node.name;
+  return { ...node, properties };
+}
+
+function toDocumentGraphMutationPayload(
+  graph: GraphDocumentForFrontend,
+  locale: LocaleEnum,
+): GraphDocumentForFrontend {
+  return {
+    nodes: graph.nodes.map((node) => syncNodeNameWithLocaleProperties(node, locale)),
+    relationships: graph.relationships.map((relationship) => ({
+      ...relationship,
+      properties: normalizePropertiesToString(relationship.properties),
+    })),
+  };
+}
+
 export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
   const router = useRouter();
+  const { data: authSession } = useSession();
+  const preferredLocale = (authSession?.user?.preferredLocale ?? "ja") as LocaleEnum;
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [graphEditError, setGraphEditError] = useState<string | null>(null);
+  const [editedGraph, setEditedGraph] =
+    useState<GraphDocumentForFrontend | null>(null);
+  const graphSyncedSessionRef = useRef<string | null>(null);
   const { data, isLoading, error, refetch } = api.scan.getSession.useQuery({
     id: sessionId,
   });
+
+  const applyServerGraph = (graph: GraphDocumentForFrontend) => {
+    setEditedGraph(graph);
+  };
+
+  const syncGraphFromServer = async () => {
+    const result = await refetch();
+    if (result.data?.graph) {
+      applyServerGraph(result.data.graph);
+    }
+    return result;
+  };
+
+  const updateGraph = api.documentGraph.updateGraph.useMutation({
+    onSuccess: async () => {
+      setGraphEditError(null);
+      await syncGraphFromServer();
+    },
+    onError: async (mutationError) => {
+      setGraphEditError(mutationError.message ?? "グラフの保存に失敗しました");
+      await syncGraphFromServer();
+    },
+  });
+
+  useEffect(() => {
+    graphSyncedSessionRef.current = null;
+    setEditedGraph(null);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!data?.graph) return;
+    if (graphSyncedSessionRef.current === sessionId) return;
+    applyServerGraph(data.graph);
+    graphSyncedSessionRef.current = sessionId;
+  }, [data?.graph, sessionId]);
   const deleteSession = api.scan.deleteSession.useMutation({
     onSuccess: () => {
       setIsDeleteOpen(false);
@@ -58,6 +136,19 @@ export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
       </div>
     );
   }
+
+  const displayGraph = editedGraph ?? data?.graph ?? null;
+
+  const handleGraphChange = (nextGraph: GraphDocumentForFrontend) => {
+    if (!data?.graphId) return;
+    setGraphEditError(null);
+    const payload = toDocumentGraphMutationPayload(nextGraph, preferredLocale);
+    setEditedGraph(payload);
+    updateGraph.mutate({
+      id: data.graphId,
+      dataJson: payload,
+    });
+  };
 
   if (error != null || data == null) {
     return (
@@ -125,14 +216,29 @@ export function FieldScanDetail({ sessionId }: FieldScanDetailProps) {
           </pre>
         </section>
 
-        <section className="">
-          <GraphPreview graphData={data.graph} />
-        </section>
+        {displayGraph && (
+          <section className="">
+            <GraphPreview graphData={displayGraph} />
+          </section>
+        )}
 
-        <GraphSummary
-          graph={data.graph}
-          matchCandidates={data.matchCandidates}
-        />
+        {displayGraph && (
+          <GraphSummary
+            graph={displayGraph}
+            matchCandidates={data.matchCandidates}
+            onGraphChange={handleGraphChange}
+            onRefreshNodeMatches={() => {
+              if (updateGraph.isPending) return;
+              void syncGraphFromServer();
+            }}
+          />
+        )}
+
+        {graphEditError && (
+          <p className="rounded-lg border border-red-500/40 bg-red-950/40 px-3 py-2 text-sm text-red-300">
+            {graphEditError}
+          </p>
+        )}
 
         <div className="flex flex-col gap-3">
           <Button

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -82,7 +82,7 @@ export function FieldScanFlow() {
       ),
     [graphPreview],
   );
-  const { data: previewMatchCandidates = [], refetch: refetchPreviewMatches } =
+  const { data: previewMatchCandidates = [] } =
     api.scan.searchNodeMatchesByNames.useQuery(
       {
         nodeNames: previewMatchNodeNames,
@@ -634,10 +634,6 @@ export function FieldScanFlow() {
                 graph={graphPreview}
                 matchCandidates={previewMatchCandidates}
                 onGraphChange={setGraphPreview}
-                onRefreshNodeMatches={() => {
-                  if (previewMatchNodeNames.length === 0) return;
-                  void refetchPreviewMatches();
-                }}
               />
 
             </>

--- a/src/features/field/components/field-scan-flow.tsx
+++ b/src/features/field/components/field-scan-flow.tsx
@@ -82,7 +82,7 @@ export function FieldScanFlow() {
       ),
     [graphPreview],
   );
-  const { data: previewMatchCandidates = [] } =
+  const { data: previewMatchCandidates = [], refetch: refetchPreviewMatches } =
     api.scan.searchNodeMatchesByNames.useQuery(
       {
         nodeNames: previewMatchNodeNames,
@@ -130,11 +130,10 @@ export function FieldScanFlow() {
   const pipelineLabel = useMemo(() => {
     if (pipelineStage === "ocr") {
       return ocrProgress
-        ? `${getOcrStatusLabel(ocrProgress)}${
-            ocrProgress.status === "recognizing text"
-              ? ` ${Math.round(ocrProgress.progress * 100)}%`
-              : ""
-          }`
+        ? `${getOcrStatusLabel(ocrProgress)}${ocrProgress.status === "recognizing text"
+          ? ` ${Math.round(ocrProgress.progress * 100)}%`
+          : ""
+        }`
         : "OCR を実行中...";
     }
     if (pipelineStage === "normalize") return "AIでテキストを整形中...";
@@ -445,150 +444,82 @@ export function FieldScanFlow() {
       )}
 
       {step !== "camera" && (
-      <div className="mx-auto flex w-full max-w-lg flex-col gap-5 px-4 py-6 pb-24 pt-14">
-        <div className="flex items-start justify-start gap-3">
-          <LinkButton
-            href="/field"
-            className="flex !h-8 !w-8 shrink-0 items-center justify-center"
-          >
-            <div className="h-4 w-4">
-              <ChevronLeftIcon width={16} height={16} color="white" />
-            </div>
-          </LinkButton>
-          <div>
-            <h1 className="text-xl font-bold text-slate-50">新規スキャン</h1>
-            <p className="text-sm text-slate-400">
-              撮影 → 領域指定 → OCR → AI整形 → グラフプレビュー
-            </p>
-          </div>
-        </div>
-
-        {previewUrl && (step === "trim" || step === "processing") && (
-          <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-            <label className="mb-2 block text-sm font-medium text-slate-200">
-              2. 文字領域を指定
-            </label>
-            <ScanRegionSelector
-              imageUrl={previewUrl}
-              regions={ocrRegions}
-              onRegionsChange={setOcrRegions}
-              defaultFullscreen
-              requireFullscreenChangeToComplete={graphPreview != null}
-              onCancelFullscreen={handleCancelRegionAdjust}
-              onCompleteFullscreen={() => {
-                if (graphPreview) setStep("preview");
-              }}
-              onRotateImage={() => void handleRotateImage()}
-              isRotatingImage={isRotatingImage}
-            />
-            <div className="mt-3 flex gap-2">
-              <Button
-                onClick={handleBackToCamera}
-                className="w-1/2 bg-slate-700 text-white"
-                disabled={step === "processing"}
-              >
-                撮り直す
-              </Button>
-              <Button
-                onClick={handleRunPipeline}
-                disabled={
-                  !imageFile ||
-                  step === "processing" ||
-                  isRunningOcr ||
-                  ocrRegions.length === 0
-                }
-                isLoading={step === "processing" || isRunningOcr}
-                className="w-1/2 bg-orange-400 text-white hover:bg-orange-500"
-              >
-                この範囲で解析
-              </Button>
-            </div>
-          </section>
-        )}
-
-        {(step === "trim" || step === "processing") && (
-          <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-            <label className="mb-2 block text-sm font-medium text-slate-200">
-              3. OCR 言語
-            </label>
-            <select
-              value={language}
-              onChange={(event) =>
-                setLanguage(event.target.value as OcrLanguage)
-              }
-              className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+        <div className="mx-auto flex w-full max-w-lg flex-col gap-5 px-4 py-6 pb-24 pt-14">
+          <div className="flex items-start justify-start gap-3">
+            <LinkButton
+              href="/field"
+              className="flex !h-8 !w-8 shrink-0 items-center justify-center"
             >
-              {LANGUAGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-
-            {isPipelineRunning && pipelineStage && (
-              <div className="mt-3">
-                <div className="mb-1 text-xs text-slate-400">
-                  {pipelineLabel}
-                </div>
-                <div className="h-2 overflow-hidden rounded-full bg-slate-700">
-                  <div
-                    className="h-full bg-orange-400 transition-all"
-                    style={{
-                      width: `${pipelineProgress}%`,
-                    }}
-                  />
-                </div>
+              <div className="h-4 w-4">
+                <ChevronLeftIcon width={16} height={16} color="white" />
               </div>
-            )}
-          </section>
-        )}
+            </LinkButton>
+            <div>
+              <h1 className="text-xl font-bold text-slate-50">新規スキャン</h1>
+            </div>
+          </div>
 
-        {step === "preview" && graphPreview && (
-          <>
-            {previewUrl && (
-              <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-                <label className="mb-2 block text-sm font-medium text-slate-200">
-                  2. 指定した文字領域
-                </label>
-                <ScanImageWithRegions
-                  imageUrl={previewUrl}
-                  regions={ocrRegions}
-                  alt="指定した文字領域"
-                />
-                <p className="mt-2 text-xs text-slate-500">
-                  領域の変更は「領域を再調整」から全画面で行えます。
-                </p>
-              </section>
-            )}
-
+          {previewUrl && (step === "trim" || step === "processing") && (
             <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-              <label
-                htmlFor="session-name"
-                className="mb-2 block text-sm font-medium text-slate-200"
-              >
-                4. セッション名
+              <label className="mb-2 block text-sm font-medium text-slate-200">
+                文字領域を指定
               </label>
-              <input
-                id="session-name"
-                value={sessionName}
-                onChange={(event) => setSessionName(event.target.value)}
-                placeholder="例: 展覧会パンフレット p.3"
-                className="mb-4 w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+              <ScanRegionSelector
+                imageUrl={previewUrl}
+                regions={ocrRegions}
+                onRegionsChange={setOcrRegions}
+                defaultFullscreen
+                requireFullscreenChangeToComplete={graphPreview != null}
+                onCancelFullscreen={handleCancelRegionAdjust}
+                onCompleteFullscreen={() => {
+                  if (graphPreview) setStep("preview");
+                }}
+                onRotateImage={() => void handleRotateImage()}
+                isRotatingImage={isRotatingImage}
               />
+              <div className="mt-3 flex gap-2">
+                <Button
+                  onClick={handleBackToCamera}
+                  className="w-1/2 bg-slate-700 text-white"
+                  disabled={step === "processing"}
+                >
+                  撮り直す
+                </Button>
+                <Button
+                  onClick={handleRunPipeline}
+                  disabled={
+                    !imageFile ||
+                    step === "processing" ||
+                    isRunningOcr ||
+                    ocrRegions.length === 0
+                  }
+                  isLoading={step === "processing" || isRunningOcr}
+                  className="w-1/2 bg-orange-400 text-white hover:bg-orange-500"
+                >
+                  この範囲で解析
+                </Button>
+              </div>
+            </section>
+          )}
 
-              <label
-                htmlFor="ocr-text"
-                className="mb-2 block text-sm font-medium text-slate-200"
-              >
-                5. OCR テキスト（AI整形済み）
+          {(step === "trim" || step === "processing") && (
+            <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+              <label className="mb-2 block text-sm font-medium text-slate-200">
+                OCR 言語
               </label>
-              <textarea
-                id="ocr-text"
-                value={plainText}
-                onChange={(event) => setPlainText(event.target.value)}
-                rows={8}
+              <select
+                value={language}
+                onChange={(event) =>
+                  setLanguage(event.target.value as OcrLanguage)
+                }
                 className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
-              />
+              >
+                {LANGUAGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
 
               {isPipelineRunning && pipelineStage && (
                 <div className="mt-3">
@@ -598,59 +529,126 @@ export function FieldScanFlow() {
                   <div className="h-2 overflow-hidden rounded-full bg-slate-700">
                     <div
                       className="h-full bg-orange-400 transition-all"
-                      style={{ width: `${pipelineProgress}%` }}
+                      style={{
+                        width: `${pipelineProgress}%`,
+                      }}
                     />
                   </div>
                 </div>
               )}
-
-              <div className="mt-3 flex gap-2">
-                <Button
-                  onClick={() => setStep("trim")}
-                  className="w-1/3 bg-slate-700 text-white"
-                >
-                  領域を再調整
-                </Button>
-                <Button
-                  onClick={() => void handleReExtractGraph()}
-                  isLoading={isRunningGraph}
-                  disabled={!plainText.trim() || isRunningGraph}
-                  className="w-1/3 bg-slate-700 text-white"
-                >
-                  再抽出して更新
-                </Button>
-                <Button
-                  onClick={() => void handleSubmit()}
-                  disabled={!canSubmit || isSubmitting}
-                  isLoading={isSubmitting}
-                  className="w-1/3 bg-orange-400 text-white hover:bg-orange-500 disabled:opacity-50"
-                >
-                  保存して詳細へ
-                </Button>
-              </div>
             </section>
+          )}
 
-            <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-              <h2 className="mb-2 text-sm font-semibold text-slate-200">
-                6. グラフプレビュー
-              </h2>
-              <GraphPreview graphData={graphPreview} />
-              <div className="mt-4">
-                <GraphSummary
-                  graph={graphPreview}
-                  matchCandidates={previewMatchCandidates}
+          {step === "preview" && graphPreview && (
+            <>
+              {previewUrl && (
+                <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+                  <label className="mb-2 block text-sm font-medium text-slate-200">
+                    指定した文字領域
+                  </label>
+                  <ScanImageWithRegions
+                    imageUrl={previewUrl}
+                    regions={ocrRegions}
+                    alt="指定した文字領域"
+                  />
+                  <p className="mt-2 text-xs text-slate-500">
+                    領域の変更は「領域を再調整」から全画面で行えます。
+                  </p>
+                </section>
+              )}
+
+              <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+                <label
+                  htmlFor="session-name"
+                  className="mb-2 block text-sm font-medium text-slate-200"
+                >
+                  セッション名
+                </label>
+                <input
+                  id="session-name"
+                  value={sessionName}
+                  onChange={(event) => setSessionName(event.target.value)}
+                  placeholder="例: 展覧会パンフレット p.3"
+                  className="mb-4 w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
                 />
-              </div>
-            </section>
-          </>
-        )}
 
-        {errorMessage && (
-          <p className="rounded-lg border border-red-500/40 bg-red-950/40 px-3 py-2 text-sm text-red-300">
-            {errorMessage}
-          </p>
-        )}
-      </div>
+                <label
+                  htmlFor="ocr-text"
+                  className="mb-2 block text-sm font-medium text-slate-200"
+                >
+                  OCR テキスト（AI整形済み）
+                </label>
+                <textarea
+                  id="ocr-text"
+                  value={plainText}
+                  onChange={(event) => setPlainText(event.target.value)}
+                  rows={8}
+                  className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                />
+
+                {isPipelineRunning && pipelineStage && (
+                  <div className="mt-3">
+                    <div className="mb-1 text-xs text-slate-400">
+                      {pipelineLabel}
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-slate-700">
+                      <div
+                        className="h-full bg-orange-400 transition-all"
+                        style={{ width: `${pipelineProgress}%` }}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <div className="mt-3 flex gap-2">
+                  <Button
+                    onClick={() => setStep("trim")}
+                    className="w-1/3 bg-slate-700 text-white"
+                  >
+                    領域を再調整
+                  </Button>
+                  <Button
+                    onClick={() => void handleReExtractGraph()}
+                    isLoading={isRunningGraph}
+                    disabled={!plainText.trim() || isRunningGraph}
+                    className="w-1/3 bg-slate-700 text-white"
+                  >
+                    再抽出して更新
+                  </Button>
+                  <Button
+                    onClick={() => void handleSubmit()}
+                    disabled={!canSubmit || isSubmitting}
+                    isLoading={isSubmitting}
+                    className="w-1/3 bg-orange-400 text-white hover:bg-orange-500 disabled:opacity-50"
+                  >
+                    保存して詳細へ
+                  </Button>
+                </div>
+              </section>
+
+
+
+              <GraphPreview graphData={graphPreview} />
+
+              <GraphSummary
+                graph={graphPreview}
+                matchCandidates={previewMatchCandidates}
+                onGraphChange={setGraphPreview}
+                onRefreshNodeMatches={() => {
+                  if (previewMatchNodeNames.length === 0) return;
+                  void refetchPreviewMatches();
+                }}
+              />
+
+            </>
+          )}
+
+          {errorMessage && (
+            <p className="rounded-lg border border-red-500/40 bg-red-950/40 px-3 py-2 text-sm text-red-300">
+              {errorMessage}
+            </p>
+          )}
+        </div>
       )}
     </FadeIn>
   );

--- a/src/features/field/components/field-session-list.tsx
+++ b/src/features/field/components/field-session-list.tsx
@@ -7,6 +7,7 @@ import { signIn, useSession } from "next-auth/react";
 import dayjs from "dayjs";
 import { api } from "@/trpc/react";
 import { Button } from "@/app/_components/button/button";
+import { PlusIcon } from "@/app/_components/icons";
 import { FadeIn } from "@/app/_components/animation/fade-in";
 import { ScanSessionMenu } from "@/features/field/components/scan-session-menu";
 import { ScanSessionRenameModal } from "@/features/field/components/scan-session-rename-modal";
@@ -88,9 +89,10 @@ export function FieldSessionList() {
 
         <Button
           onClick={() => router.push("/field/scan")}
-          className="w-full bg-orange-400 text-white hover:bg-orange-500"
+          className="flex w-full flex-row items-center justify-center gap-1 bg-orange-400 text-white hover:bg-orange-500"
         >
-          新規スキャン
+          <PlusIcon width={16} height={16} color="white" />
+          <div className="text-sm">新規スキャン</div>
         </Button>
 
         {isLoading && (

--- a/src/features/field/components/graph-summary-edit-modal.tsx
+++ b/src/features/field/components/graph-summary-edit-modal.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { Modal } from "@/app/_components/modal/modal";
+import { Button } from "@/app/_components/button/button";
+import { TextInput } from "@/app/_components/input/text-input";
+import type { PropertyTypeForFrontend } from "@/app/const/types";
+
+function getDescription(properties: PropertyTypeForFrontend): string {
+  return properties.description?.trim() ?? "";
+}
+
+function withDescription(
+  properties: PropertyTypeForFrontend,
+  description: string,
+): PropertyTypeForFrontend {
+  const trimmed = description.trim();
+  if (!trimmed) {
+    const next = { ...properties };
+    delete next.description;
+    return next;
+  }
+  return { ...properties, description: trimmed };
+}
+
+export type GraphNodeEditPayload = {
+  kind: "node";
+  id: string;
+  name: string;
+  label: string;
+  properties: PropertyTypeForFrontend;
+};
+
+export type GraphRelationshipEditPayload = {
+  kind: "relationship";
+  id: string;
+  type: string;
+  properties: PropertyTypeForFrontend;
+  sourceName: string;
+  targetName: string;
+};
+
+export type GraphItemEditPayload =
+  | GraphNodeEditPayload
+  | GraphRelationshipEditPayload;
+
+type GraphSummaryEditModalProps = {
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  item: GraphItemEditPayload | null;
+  onSave: (item: GraphItemEditPayload) => void;
+};
+
+export function GraphSummaryEditModal({
+  isOpen,
+  setIsOpen,
+  item,
+  onSave,
+}: GraphSummaryEditModalProps) {
+  const [name, setName] = useState("");
+  const [type, setType] = useState("");
+  const [description, setDescription] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !item) return;
+    setErrorMessage(null);
+    if (item.kind === "node") {
+      setName(item.name);
+      setType("");
+      setDescription(getDescription(item.properties));
+    } else {
+      setName("");
+      setType(item.type);
+      setDescription(getDescription(item.properties));
+    }
+  }, [isOpen, item]);
+
+  const handleSave = () => {
+    if (!item) return;
+
+    if (item.kind === "node") {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        setErrorMessage("ノード名を入力してください");
+        return;
+      }
+      onSave({
+        ...item,
+        name: trimmedName,
+        properties: withDescription(item.properties, description),
+      });
+    } else {
+      const trimmedType = type.trim();
+      if (!trimmedType) {
+        setErrorMessage("関係タイプを入力してください");
+        return;
+      }
+      onSave({
+        ...item,
+        type: trimmedType,
+        properties: withDescription(item.properties, description),
+      });
+    }
+
+    setIsOpen(false);
+  };
+
+  if (!item) return null;
+
+  const title = item.kind === "node" ? "ノードを編集" : "関係を編集";
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} title={title}>
+      <div className="flex flex-col gap-4">
+        {item.kind === "relationship" && (
+          <p className="text-sm text-slate-300">
+            {item.sourceName} → {item.targetName}
+          </p>
+        )}
+
+        {item.kind === "node" ? (
+          <div className="flex flex-col gap-1">
+            <label className="text-sm text-slate-200">ノード名</label>
+            <TextInput
+              value={name}
+              onChange={setName}
+              placeholder="ノード名"
+            />
+            {item.label ? (
+              <p className="text-xs text-slate-500">ラベル: {item.label}</p>
+            ) : null}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            <label className="text-sm text-slate-200">関係タイプ</label>
+            <TextInput
+              value={type}
+              onChange={setType}
+              placeholder="例: 関連, 影響"
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-slate-200">解説・メモ</label>
+          <textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            rows={4}
+            placeholder="現地調査のメモや補足説明（properties.description に保存）"
+            className="w-full resize-y rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-orange-400/50 focus:ring-2"
+          />
+        </div>
+
+        {errorMessage && (
+          <p className="text-sm text-red-300">{errorMessage}</p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            className="!text-small !p-1 text-slate-400"
+            onClick={() => setIsOpen(false)}
+          >
+            キャンセル
+          </Button>
+          <Button className="!text-small !p-1" onClick={handleSave}>
+            OK
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/field/components/graph-summary-edit-modal.tsx
+++ b/src/features/field/components/graph-summary-edit-modal.tsx
@@ -6,21 +6,22 @@ import { Button } from "@/app/_components/button/button";
 import { TextInput } from "@/app/_components/input/text-input";
 import type { PropertyTypeForFrontend } from "@/app/const/types";
 
-function getDescription(properties: PropertyTypeForFrontend): string {
-  return properties.description?.trim() ?? "";
+function getDescription(properties: PropertyTypeForFrontend | undefined): string {
+  return properties?.description?.trim() ?? "";
 }
 
 function withDescription(
-  properties: PropertyTypeForFrontend,
+  properties: PropertyTypeForFrontend | undefined,
   description: string,
 ): PropertyTypeForFrontend {
   const trimmed = description.trim();
+  const safeProperties = properties ?? {};
   if (!trimmed) {
-    const next = { ...properties };
+    const next = { ...safeProperties };
     delete next.description;
     return next;
   }
-  return { ...properties, description: trimmed };
+  return { ...safeProperties, description: trimmed };
 }
 
 export type GraphNodeEditPayload = {

--- a/src/features/field/components/graph-summary.tsx
+++ b/src/features/field/components/graph-summary.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import { CheckIcon, Pencil2Icon } from "@/app/_components/icons";
 import type { GraphDocumentForFrontend } from "@/app/const/types";
 import type { PublishedNodeMatch } from "@/server/api/schemas/scan";
+import {
+  GraphSummaryEditModal,
+  type GraphItemEditPayload,
+} from "@/features/field/components/graph-summary-edit-modal";
 
 type GraphSummaryProps = {
   graph: GraphDocumentForFrontend;
   matchCandidates?: PublishedNodeMatch[];
+  onGraphChange?: (graph: GraphDocumentForFrontend) => void;
+  /** 編集モード終了時にノード名が変わっていた場合に呼ばれる（一致候補の再取得用） */
+  onRefreshNodeMatches?: () => void;
 };
 
 function normalizeNodeName(name: string | undefined | null): string {
@@ -70,12 +78,20 @@ function NodeMatchPreview({ matches }: { matches: PublishedNodeMatch[] }) {
             ) : match.sourceType === "sourceDocument" &&
               match.sourceDocumentId ? (
               <Link
-                href={`/documents/${match.sourceDocumentId}`}
+                href={
+                  match.sourceDocumentType === "INPUT_SCAN"
+                    ? `/field/scan/${match.sourceDocumentId}`
+                    : `/documents/${match.sourceDocumentId}`
+                }
                 target="_blank"
                 rel="noopener noreferrer"
                 className="mt-2 inline-block text-sm text-orange-300 underline-offset-2 hover:underline"
               >
-                {match.sourceDocumentName ?? "ドキュメント"} を開く
+                {match.sourceDocumentName ??
+                  (match.sourceDocumentType === "INPUT_SCAN"
+                    ? "スキャン"
+                    : "ドキュメント")}{" "}
+                を開く
               </Link>
             ) : match.sourceType === "workspace" && match.workspaceId ? (
               <Link
@@ -93,23 +109,61 @@ function NodeMatchPreview({ matches }: { matches: PublishedNodeMatch[] }) {
       {(topicSpaceMatches.length > 0 ||
         sourceDocumentMatches.length > 0 ||
         workspaceMatches.length > 0) && (
-        <p className="mt-2 text-xs text-slate-400">
-          トピックスペース {topicSpaceMatches.length} 件 / ドキュメント{" "}
-          {sourceDocumentMatches.length} 件
-          {workspaceMatches.length > 0
-            ? ` / 公開グラフ ${workspaceMatches.length} 件`
-            : ""}
-        </p>
-      )}
+          <p className="mt-2 text-xs text-slate-400">
+            トピックスペース {topicSpaceMatches.length} 件 / ドキュメント{" "}
+            {sourceDocumentMatches.length} 件
+            {workspaceMatches.length > 0
+              ? ` / 公開グラフ ${workspaceMatches.length} 件`
+              : ""}
+          </p>
+        )}
     </div>
+  );
+}
+
+type EditModeTriggerProps = {
+  isEditMode: boolean;
+  onClick: () => void;
+  className?: string;
+  children: ReactNode;
+};
+
+function EditModeTrigger({
+  isEditMode,
+  onClick,
+  className = "",
+  children,
+}: EditModeTriggerProps) {
+  if (!isEditMode) {
+    return <>{children}</>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`max-w-full cursor-pointer rounded-lg text-left transition hover:ring-2 hover:ring-orange-400/50 ${className}`}
+    >
+      {children}
+    </button>
   );
 }
 
 export function GraphSummary({
   graph,
   matchCandidates = [],
+  onGraphChange,
+  onRefreshNodeMatches,
 }: GraphSummaryProps) {
+  const canEdit = onGraphChange != null;
+  const [isEditMode, setIsEditMode] = useState(false);
+  const nodeNamesAtEditStartRef = useRef<Map<string, string>>(new Map());
   const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null);
+  const [editingItem, setEditingItem] = useState<GraphItemEditPayload | null>(
+    null,
+  );
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
   const nodesMap = new Map(graph.nodes.map((node) => [node.id, node]));
   const matchesByName = useMemo(
     () => groupMatchesByName(matchCandidates),
@@ -119,123 +173,310 @@ export function GraphSummary({
     (node) => (matchesByName.get(normalizeNodeName(node.name))?.length ?? 0) > 0,
   ).length;
 
-  return (
-    <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <h2 className="text-sm font-semibold text-slate-200">グラフ</h2>
-        <span className="text-xs text-slate-400">
-          ノード {graph.nodes.length} · 関係 {graph.relationships.length}
-        </span>
-      </div>
+  const openNodeEditor = (nodeId: string) => {
+    const node = nodesMap.get(nodeId);
+    if (!node) return;
+    setEditingItem({
+      kind: "node",
+      id: node.id,
+      name: node.name,
+      label: node.label,
+      properties: node.properties,
+    });
+    setIsEditModalOpen(true);
+  };
 
-      {graph.nodes.length > 0 && (
-        <div className="mb-4">
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <h3 className="text-xs font-medium uppercase tracking-wide text-slate-400">
-              ノード
-            </h3>
-            {matchedNodeCount > 0 && (
-              <span className="text-xs text-orange-300">
-                {matchedNodeCount} 件が既存データと一致
-              </span>
+  const openRelationshipEditor = (relationshipId: string) => {
+    const relationship = graph.relationships.find((r) => r.id === relationshipId);
+    if (!relationship) return;
+    const source = nodesMap.get(relationship.sourceId);
+    const target = nodesMap.get(relationship.targetId);
+    setEditingItem({
+      kind: "relationship",
+      id: relationship.id,
+      type: relationship.type,
+      properties: relationship.properties,
+      sourceName: source?.name ?? "?",
+      targetName: target?.name ?? "?",
+    });
+    setIsEditModalOpen(true);
+  };
+
+  const enterEditMode = () => {
+    nodeNamesAtEditStartRef.current = new Map(
+      graph.nodes.map((node) => [node.id, node.name]),
+    );
+    setIsEditMode(true);
+  };
+
+  const exitEditMode = () => {
+    const namesChanged = graph.nodes.some(
+      (node) => nodeNamesAtEditStartRef.current.get(node.id) !== node.name,
+    );
+    setIsEditMode(false);
+    setExpandedNodeId(null);
+    setIsEditModalOpen(false);
+    if (namesChanged) {
+      onRefreshNodeMatches?.();
+    }
+  };
+
+  const handleSaveEdit = (item: GraphItemEditPayload) => {
+    if (!onGraphChange) return;
+
+    if (item.kind === "node") {
+      onGraphChange({
+        ...graph,
+        nodes: graph.nodes.map((node) =>
+          node.id === item.id
+            ? {
+              ...node,
+              name: item.name,
+              properties: item.properties,
+            }
+            : node,
+        ),
+      });
+      return;
+    }
+
+    onGraphChange({
+      ...graph,
+      relationships: graph.relationships.map((relationship) =>
+        relationship.id === item.id
+          ? {
+            ...relationship,
+            type: item.type,
+            properties: item.properties,
+          }
+          : relationship,
+      ),
+    });
+  };
+
+  return (
+    <>
+      <section className="rounded-xl border border-slate-700 bg-slate-800/60 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-slate-200">グラフ</h2>
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="text-xs text-slate-400">
+              ノード {graph.nodes.length} · 関係 {graph.relationships.length}
+            </span>
+            {canEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                if (isEditMode) {
+                  exitEditMode();
+                } else {
+                  enterEditMode();
+                }
+                }}
+                aria-label={isEditMode ? "編集モードを終了" : "編集モード"}
+                aria-pressed={isEditMode}
+                className={`flex h-8 w-8 items-center justify-center rounded-md transition ${isEditMode
+                  ? "bg-orange-500/25 text-orange-200 ring-1 ring-orange-400/60"
+                  : "text-slate-300 hover:bg-slate-700/80 hover:text-white"
+                  }`}
+              >
+                <Pencil2Icon width={16} height={16} color="currentColor" />
+              </button>
             )}
           </div>
-          <ul className="flex flex-col gap-2">
-            {graph.nodes.map((node) => {
-              const matches =
-                matchesByName.get(normalizeNodeName(node.name)) ?? [];
-              const hasMatches = matches.length > 0;
-              const isExpanded = expandedNodeId === node.id;
-              const hasSourceDocumentMatch = matches.some(
-                (match) => match.sourceType === "sourceDocument",
-              );
-              const hasTopicSpaceMatch = matches.some(
-                (match) => match.sourceType === "topicSpace",
-              );
-              const highlightTone = hasSourceDocumentMatch
-                ? "orange"
-                : hasTopicSpaceMatch
-                  ? "emerald"
-                  : "none";
-
-              return (
-                <li key={node.id} className="flex flex-col gap-2">
-                  {hasMatches && highlightTone === "orange" ? (
-                    <button
-                      type="button"
-                      aria-expanded={isExpanded}
-                      onClick={() =>
-                        setExpandedNodeId(isExpanded ? null : node.id)
-                      }
-                      className={`inline-flex w-fit max-w-full items-center gap-2 rounded-full border px-3 py-1 text-left text-sm transition-colors ${isExpanded
-                        ? "border-orange-400 bg-orange-500/20 text-orange-100"
-                        : "border-orange-500/60 bg-orange-500/10 text-orange-100 hover:border-orange-400 hover:bg-orange-500/15"
-                        }`}
-                    >
-                      <span className="truncate">{node.name}</span>
-                      <span className="shrink-0 text-xs text-orange-300/60">
-                        {matches.length}
-                      </span>
-                    </button>
-                  ) : hasMatches ? (
-                    <button
-                      type="button"
-                      aria-expanded={isExpanded}
-                      onClick={() =>
-                        setExpandedNodeId(isExpanded ? null : node.id)
-                      }
-                      className={`inline-flex w-fit max-w-full items-center gap-2 rounded-full border px-3 py-1 text-left text-sm transition-colors ${isExpanded
-                        ? "border-emerald-400 bg-emerald-500/20 text-emerald-100"
-                        : "border-emerald-500/60 bg-emerald-500/10 text-emerald-100 hover:border-emerald-400 hover:bg-emerald-500/15"
-                        }`}
-                    >
-                      <span className="truncate">{node.name}</span>
-                      <span className="shrink-0 text-xs text-emerald-300/50">
-                        {matches.length}
-                      </span>
-                    </button>
-                  ) : (
-                    <span className="inline-flex w-fit max-w-full rounded-full border border-slate-600 bg-slate-900 px-3 py-1 text-sm text-slate-100">
-                      {node.name}
-                    </span>
-                  )}
-
-                  {hasMatches && isExpanded && (
-                    <NodeMatchPreview matches={matches} />
-                  )}
-                </li>
-              );
-            })}
-          </ul>
         </div>
-      )}
 
-      {graph.relationships.length > 0 && (
-        <div>
-          <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
-            関係
-          </h3>
-          <ul className="flex flex-col gap-2">
-            {graph.relationships.map((relationship) => {
-              const source = nodesMap.get(relationship.sourceId);
-              const target = nodesMap.get(relationship.targetId);
-              return (
-                <li
-                  key={relationship.id}
-                  className="rounded-lg bg-slate-900/70 px-3 py-2 text-sm text-slate-200"
-                >
-                  {source?.name ?? "?"} → {target?.name ?? "?"}
-                  {relationship.type ? (
-                    <span className="ml-2 text-xs text-slate-400">
-                      ({relationship.type})
-                    </span>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        {isEditMode && (
+          <p className="mb-3 text-xs text-slate-500">
+            ノードまたは関係をタップして編集できます。
+          </p>
+        )}
+
+        {graph.nodes.length > 0 && (
+          <div className="mb-4">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                ノード
+              </h3>
+              {matchedNodeCount > 0 && (
+                <span className="text-xs text-orange-300">
+                  {matchedNodeCount} 件が既存データと一致
+                </span>
+              )}
+            </div>
+            <ul className="flex flex-col gap-2">
+              {graph.nodes.map((node) => {
+                const matches =
+                  matchesByName.get(normalizeNodeName(node.name)) ?? [];
+                const hasMatches = matches.length > 0;
+                const isExpanded = expandedNodeId === node.id;
+                const hasSourceDocumentMatch = matches.some(
+                  (match) => match.sourceType === "sourceDocument",
+                );
+                const hasTopicSpaceMatch = matches.some(
+                  (match) => match.sourceType === "topicSpace",
+                );
+                const highlightTone = hasSourceDocumentMatch
+                  ? "orange"
+                  : hasTopicSpaceMatch
+                    ? "emerald"
+                    : "none";
+
+                const pillOrangeClass = isExpanded
+                  ? "border-orange-400 bg-orange-500/20 text-orange-100"
+                  : "border-orange-500/60 bg-orange-500/10 text-orange-100 hover:border-orange-400 hover:bg-orange-500/15";
+                const pillEmeraldClass = isExpanded
+                  ? "border-emerald-400 bg-emerald-500/20 text-emerald-100"
+                  : "border-emerald-500/60 bg-emerald-500/10 text-emerald-100 hover:border-emerald-400 hover:bg-emerald-500/15";
+
+                return (
+                  <li key={node.id} className="flex flex-col gap-2">
+                    {hasMatches && highlightTone === "orange" ? (
+                      <EditModeTrigger
+                        isEditMode={isEditMode}
+                        onClick={() => openNodeEditor(node.id)}
+                      >
+                        <span
+                          role={isEditMode ? undefined : "button"}
+                          tabIndex={isEditMode ? undefined : 0}
+                          aria-expanded={isEditMode ? undefined : isExpanded}
+                          onClick={
+                            isEditMode
+                              ? undefined
+                              : () =>
+                                setExpandedNodeId(isExpanded ? null : node.id)
+                          }
+                          onKeyDown={
+                            isEditMode
+                              ? undefined
+                              : (event) => {
+                                if (
+                                  event.key === "Enter" ||
+                                  event.key === " "
+                                ) {
+                                  setExpandedNodeId(
+                                    isExpanded ? null : node.id,
+                                  );
+                                }
+                              }
+                          }
+                          className={`inline-flex w-fit max-w-full items-center gap-2 rounded-full border px-3 py-1 text-left text-sm transition-colors ${pillOrangeClass}`}
+                        >
+                          <span className="truncate">{node.name}</span>
+                          <span className="shrink-0 text-xs text-orange-300/60">
+                            {matches.length}
+                          </span>
+                        </span>
+                      </EditModeTrigger>
+                    ) : hasMatches ? (
+                      <EditModeTrigger
+                        isEditMode={isEditMode}
+                        onClick={() => openNodeEditor(node.id)}
+                      >
+                        <span
+                          role={isEditMode ? undefined : "button"}
+                          tabIndex={isEditMode ? undefined : 0}
+                          aria-expanded={isEditMode ? undefined : isExpanded}
+                          onClick={
+                            isEditMode
+                              ? undefined
+                              : () =>
+                                setExpandedNodeId(isExpanded ? null : node.id)
+                          }
+                          onKeyDown={
+                            isEditMode
+                              ? undefined
+                              : (event) => {
+                                if (
+                                  event.key === "Enter" ||
+                                  event.key === " "
+                                ) {
+                                  setExpandedNodeId(
+                                    isExpanded ? null : node.id,
+                                  );
+                                }
+                              }
+                          }
+                          className={`inline-flex w-fit max-w-full items-center gap-2 rounded-full border px-3 py-1 text-left text-sm transition-colors ${pillEmeraldClass}`}
+                        >
+                          <span className="truncate">{node.name}</span>
+                          <span className="shrink-0 text-xs text-emerald-300/50">
+                            {matches.length}
+                          </span>
+                        </span>
+                      </EditModeTrigger>
+                    ) : (
+                      <EditModeTrigger
+                        isEditMode={isEditMode}
+                        onClick={() => openNodeEditor(node.id)}
+                      >
+                        <span className="inline-flex w-fit max-w-full rounded-full border border-slate-600 bg-slate-900 px-3 py-1 text-sm text-slate-100">
+                          {node.name}
+                        </span>
+                      </EditModeTrigger>
+                    )}
+
+                    {!isEditMode && hasMatches && isExpanded && (
+                      <NodeMatchPreview matches={matches} />
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {graph.relationships.length > 0 && (
+          <div>
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              関係
+            </h3>
+            <ul className="flex flex-col gap-2">
+              {graph.relationships.map((relationship) => {
+                const source = nodesMap.get(relationship.sourceId);
+                const target = nodesMap.get(relationship.targetId);
+
+                return (
+                  <li key={relationship.id}>
+                    <EditModeTrigger
+                      isEditMode={isEditMode}
+                      onClick={() => openRelationshipEditor(relationship.id)}
+                      className="block w-full"
+                    >
+                      <div className="rounded-lg bg-slate-900/70 px-3 py-2 text-sm text-slate-200">
+                        {source?.name ?? "?"} → {target?.name ?? "?"}
+                        {relationship.type ? (
+                          <span className="ml-2 text-xs text-slate-400">
+                            ({relationship.type})
+                          </span>
+                        ) : null}
+                      </div>
+                    </EditModeTrigger>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        <GraphSummaryEditModal
+          isOpen={isEditModalOpen}
+          setIsOpen={setIsEditModalOpen}
+          item={editingItem}
+          onSave={handleSaveEdit}
+        />
+      </section>
+
+      {isEditMode && (
+        <button
+          type="button"
+          onClick={exitEditMode}
+          aria-label="編集モードを終了"
+          className="fixed bottom-6 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-white shadow-lg ring-2 ring-white/20 transition hover:bg-emerald-500 active:scale-95"
+        >
+          <CheckIcon width={24} height={24} color="white" />
+        </button>
       )}
-    </section>
+    </>
   );
 }

--- a/src/features/field/components/live-camera-scanner.tsx
+++ b/src/features/field/components/live-camera-scanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/app/_components/button/button";
 import { ChevronLeftIcon } from "@/app/_components/icons";
 import {
@@ -39,6 +39,11 @@ export function LiveCameraScanner({
     [isStarting, isCapturing, errorMessage],
   );
 
+  const releaseCamera = useCallback(() => {
+    stopCameraStream(streamRef.current, videoRef.current);
+    streamRef.current = null;
+  }, []);
+
   useEffect(() => {
     let isActive = true;
 
@@ -70,10 +75,9 @@ export function LiveCameraScanner({
 
     return () => {
       isActive = false;
-      stopCameraStream(streamRef.current);
-      streamRef.current = null;
+      releaseCamera();
     };
-  }, []);
+  }, [releaseCamera]);
 
   const handleCapture = async () => {
     const video = videoRef.current;
@@ -85,12 +89,18 @@ export function LiveCameraScanner({
 
     try {
       const file = await captureStillPhotoFromStream(stream, video);
+      releaseCamera();
       onCapture(file);
     } catch {
       setErrorMessage("撮影に失敗しました。もう一度お試しください。");
     } finally {
       setIsCapturing(false);
     }
+  };
+
+  const handleBack = () => {
+    releaseCamera();
+    onBack();
   };
 
   return (
@@ -113,7 +123,7 @@ export function LiveCameraScanner({
         <div className="pointer-events-auto flex px-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
           <button
             type="button"
-            onClick={onBack}
+            onClick={handleBack}
             aria-label="戻る"
             className="flex h-10 w-10 items-center justify-center rounded-full bg-black/45 text-white backdrop-blur-sm transition hover:bg-black/60"
           >

--- a/src/features/field/ocr/camera-capture.ts
+++ b/src/features/field/ocr/camera-capture.ts
@@ -192,6 +192,13 @@ export async function captureStillPhotoFromStream(
   return captureFromVideoElement(video);
 }
 
-export function stopCameraStream(stream: MediaStream | null): void {
+export function stopCameraStream(
+  stream: MediaStream | null,
+  video?: HTMLVideoElement | null,
+): void {
   stream?.getTracks().forEach((track) => track.stop());
+  if (video) {
+    video.pause();
+    video.srcObject = null;
+  }
 }

--- a/src/server/api/routers/document-graph.ts
+++ b/src/server/api/routers/document-graph.ts
@@ -11,7 +11,7 @@ import type {
   NodeTypeForFrontend,
   RelationshipTypeForFrontend,
 } from "@/app/const/types";
-import { getTextFromDocumentFile } from "@/app/_utils/text/text";
+import { resolveSourceDocumentPlainText } from "@/server/services/scan/resolve-source-document-plain-text";
 import { formGraphDataForFrontend } from "@/app/_utils/kg/frontend-properties";
 import { KnowledgeGraphInputSchema } from "../schemas/knowledge-graph";
 import { updateDocumentGraph } from "@/server/services/kg/update-document-graph.service";
@@ -53,10 +53,11 @@ export const documentGraphRouter = createTRPCRouter({
         }),
         sourceDocument: {
           ...graph.sourceDocument,
-          text: await getTextFromDocumentFile(
-            graph.sourceDocument.url,
-            graph.sourceDocument.documentType,
-          ),
+          text: await resolveSourceDocumentPlainText({
+            url: graph.sourceDocument.url,
+            documentType: graph.sourceDocument.documentType,
+            ocrMetadata: graph.sourceDocument.ocrMetadata,
+          }),
         },
       };
     }),

--- a/src/server/api/routers/source-document.ts
+++ b/src/server/api/routers/source-document.ts
@@ -10,7 +10,7 @@ import type { LocaleEnum } from "@/app/const/types";
 import { BUCKETS } from "@/app/_utils/supabase/const";
 import { storageUtils } from "@/app/_utils/supabase/supabase";
 import { env } from "@/env";
-import { getTextFromDocumentFile } from "@/app/_utils/text/text";
+import { resolveSourceDocumentPlainText } from "@/server/services/scan/resolve-source-document-plain-text";
 import type { PrismaClient } from "@prisma/client";
 import { formDocumentGraphForFrontend } from "@/app/_utils/kg/frontend-properties";
 import { extractRelevantSections } from "@/app/_utils/text/extract-relevant-sections";
@@ -61,10 +61,11 @@ export const getTextReference = async (
     throw new Error("Document not found");
   }
 
-  const fullText = await getTextFromDocumentFile(
-    document.url,
-    document.documentType,
-  );
+  const fullText = await resolveSourceDocumentPlainText({
+    url: document.url,
+    documentType: document.documentType,
+    ocrMetadata: document.ocrMetadata,
+  });
 
   console.log("fullText: ", fullText.slice(0, 20));
 
@@ -133,10 +134,11 @@ export const sourceDocumentRouter = createTRPCRouter({
           document.graph,
           ctx.session?.user.preferredLocale as LocaleEnum,
         ),
-        text: await getTextFromDocumentFile(
-          document.url,
-          document.documentType,
-        ),
+        text: await resolveSourceDocumentPlainText({
+          url: document.url,
+          documentType: document.documentType,
+          ocrMetadata: document.ocrMetadata,
+        }),
       };
     }),
 

--- a/src/server/api/schemas/scan.ts
+++ b/src/server/api/schemas/scan.ts
@@ -1,3 +1,4 @@
+import { DocumentType } from "@prisma/client";
 import { z } from "zod";
 import { GraphDocumentFrontendSchema } from "@/server/api/schemas/knowledge-graph";
 
@@ -68,6 +69,7 @@ export const PublishedNodeMatchSchema = z.object({
   topicSpaceName: z.string().optional(),
   sourceDocumentId: z.string().optional(),
   sourceDocumentName: z.string().optional(),
+  sourceDocumentType: z.nativeEnum(DocumentType).optional(),
 });
 
 export type OcrMetadata = z.infer<typeof OcrMetadataSchema>;

--- a/src/server/services/scan/resolve-source-document-plain-text.ts
+++ b/src/server/services/scan/resolve-source-document-plain-text.ts
@@ -13,11 +13,19 @@ export async function resolveSourceDocumentPlainText(
   document: SourceDocumentTextSource,
 ): Promise<string> {
   if (document.documentType === DocumentType.INPUT_SCAN) {
-    return resolveScanPlainText(
-      document.url,
-      document.documentType,
-      document.ocrMetadata as OcrMetadata | null,
-    );
+    try {
+      return await resolveScanPlainText(
+        document.url,
+        document.documentType,
+        document.ocrMetadata as OcrMetadata | null,
+      );
+    } catch (error) {
+      console.error("Failed to resolve scan plain text", {
+        documentType: document.documentType,
+        error,
+      });
+      return "";
+    }
   }
 
   const url = document.url?.trim();

--- a/src/server/services/scan/resolve-source-document-plain-text.ts
+++ b/src/server/services/scan/resolve-source-document-plain-text.ts
@@ -1,0 +1,37 @@
+import { DocumentType } from "@prisma/client";
+import { getTextFromDocumentFile } from "@/app/_utils/text/text";
+import type { OcrMetadata } from "@/server/api/schemas/scan";
+import { resolveScanPlainText } from "@/server/services/scan/resolve-scan-plain-text";
+
+type SourceDocumentTextSource = {
+  url: string;
+  documentType: DocumentType;
+  ocrMetadata: unknown;
+};
+
+export async function resolveSourceDocumentPlainText(
+  document: SourceDocumentTextSource,
+): Promise<string> {
+  if (document.documentType === DocumentType.INPUT_SCAN) {
+    return resolveScanPlainText(
+      document.url,
+      document.documentType,
+      document.ocrMetadata as OcrMetadata | null,
+    );
+  }
+
+  const url = document.url?.trim();
+  if (!url) {
+    return "";
+  }
+
+  try {
+    return await getTextFromDocumentFile(url, document.documentType);
+  } catch (error) {
+    console.error("Failed to load source document text", {
+      documentType: document.documentType,
+      error,
+    });
+    return "";
+  }
+}

--- a/src/server/services/scan/search-user-node-matches.service.ts
+++ b/src/server/services/scan/search-user-node-matches.service.ts
@@ -88,7 +88,11 @@ export async function searchUserSourceDocumentNodeMatchesByNames(
           userId: ctx.session.user.id,
           isDeleted: false,
           documentType: {
-            in: [DocumentType.INPUT_PDF, DocumentType.INPUT_TXT],
+            in: [
+              DocumentType.INPUT_PDF,
+              DocumentType.INPUT_TXT,
+              DocumentType.INPUT_SCAN,
+            ],
           },
           ...(excludeSourceDocumentId
             ? {
@@ -110,6 +114,7 @@ export async function searchUserSourceDocumentNodeMatchesByNames(
             select: {
               id: true,
               name: true,
+              documentType: true,
             },
           },
         },
@@ -130,6 +135,7 @@ export async function searchUserSourceDocumentNodeMatchesByNames(
       sourceType: "sourceDocument",
       sourceDocumentId: sourceDocument.id,
       sourceDocumentName: sourceDocument.name,
+      sourceDocumentType: sourceDocument.documentType,
     });
   }
 


### PR DESCRIPTION
## Summary
- フィールドスキャンのプレビュー/詳細でグラフ一覧を編集モード＋モーダル保存に対応
- ノード一致検索に INPUT_SCAN（他スキャン）を含め、スキャン詳細では自身を除外
- スキャン詳細のノード名保存時に `name_{locale}` プロパティも同期
- `documentGraph.getById` / `sourceDocument.getById` の本文取得を統一（PDF は pdf-parse 直接利用、tmp 自動作成）
- カメラ撮影後にストリームを解放、TextInput の controlled/uncontrolled 修正

## Test plan
- [ ] `npm run build` が通ること
- [ ] 新規スキャン → プレビューで編集モード・ノード名変更・一致候補更新
- [ ] スキャン詳細で編集保存後も名称が保持されること
- [ ] ドキュメント一覧 → GraphIcon でフルグラフが開けること（PDF）
- [ ] 撮影後カメラインジケーターが消えること

Made with [Cursor](https://cursor.com)