### PR TITLE
feat: add degree distribution metrics to graph statistics panel

### DIFF
--- a/src/app/_components/d3/force/graph-info-panel.tsx
+++ b/src/app/_components/d3/force/graph-info-panel.tsx
@@ -84,11 +84,17 @@ export const GraphInfoPanel = ({
       summary: {
         nodeCount,
         edgeCount: linkCount,
+        avgDegree: graphStatistics.avgDegree,
+        density: graphStatistics.density,
+        degreeStdDev: graphStatistics.degreeStdDev,
+        maxDegree: graphStatistics.maxDegree,
+        hubDependencyRatio: graphStatistics.hubDependencyRatio,
         diameter: graphStatistics.diameter,
         avgPathLength: graphStatistics.avgPathLength,
         avgClusteringCoeff: graphStatistics.avgClusteringCoeff,
         globalClusteringCoeff: graphStatistics.globalClusteringCoeff,
       },
+      degreeDistribution: graphStatistics.degreeDistribution,
       distributions: {
         nodeTypes: nodeTypeCounts,
         edgeTypes: linkTypeCounts,
@@ -151,64 +157,119 @@ export const GraphInfoPanel = ({
                 </div>
                 <div>概要を表示</div>
               </DisclosureButton>
-              <DisclosurePanel className="flex flex-col gap-2 pl-6 text-sm text-slate-200">
-                <div>ノード数: {nodeCount}</div>
-                <div>エッジ数: {linkCount}</div>
-                <div>
-                  平均ホップ数: {graphStatistics.avgPathLength.toFixed(2)}
-                </div>
-                <div>直径: {graphStatistics.diameter}</div>
-                <div>
-                  大域的クラスター係数:{" "}
-                  {graphStatistics.globalClusteringCoeff?.toFixed(3)}
-                </div>
-                <div>
-                  平均クラスター係数:{" "}
-                  {graphStatistics.avgClusteringCoeff?.toFixed(3)}
+              <DisclosurePanel className="flex flex-col gap-3 pl-6 text-sm text-slate-200">
+                {/* 基本統計 */}
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">基本統計</div>
+                  <div className="pl-2">
+                    <div>ノード数: {nodeCount}</div>
+                    <div>エッジ数: {linkCount}</div>
+                  </div>
                 </div>
 
-                <div className="font-semibold text-slate-400">
-                  重要エンティティ（ハブ）:
-                </div>
-                <div className="flex flex-col gap-1 pl-2">
-                  {graphStatistics.topDegreeNodes.map((node) => (
-                    <button
-                      key={node.id}
-                      className="flex w-full cursor-pointer items-center justify-between rounded p-1 text-left hover:bg-white/10"
-                      onClick={() => setFocusNode(node)}
-                    >
-                      <span className="flex-1 truncate text-xs">
-                        {node.name}
-                      </span>
-                      <span className="ml-2 rounded bg-slate-600 px-1 text-xs">
-                        {node.degree}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-
-                <div className="font-semibold text-slate-400">
-                  ノードタイプ内訳:
-                </div>
-                <div className="pl-2">
-                  {Object.entries(nodeTypeCounts).map(([type, count]) => (
-                    <div key={type} className="flex justify-between">
-                      <span>{type}</span>
-                      <span>{count}</span>
+                {/* 次数分析 */}
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">次数分析</div>
+                  <div className="flex flex-col gap-0.5 pl-2">
+                    <div>
+                      平均次数 (K): {graphStatistics.avgDegree.toFixed(2)}
                     </div>
-                  ))}
+                    <div>
+                      次数の標準偏差: {graphStatistics.degreeStdDev.toFixed(2)}
+                    </div>
+                    <div>
+                      最大次数:{" "}
+                      {graphStatistics.maxDegreeNode
+                        ? `${graphStatistics.maxDegreeNode.name} (${graphStatistics.maxDegree})`
+                        : graphStatistics.maxDegree}
+                    </div>
+                    <div>
+                      ハブ依存度:{" "}
+                      {(graphStatistics.hubDependencyRatio * 100).toFixed(1)}%
+                    </div>
+                    <div>
+                      密度 (ρ): {graphStatistics.density.toFixed(4)}
+                    </div>
+                  </div>
                 </div>
 
-                <div className="font-semibold text-slate-400">
-                  エッジタイプ内訳:
-                </div>
-                <div className="pl-2">
-                  {Object.entries(linkTypeCounts).map(([type, count]) => (
-                    <div key={type} className="flex justify-between">
-                      <span>{type}</span>
-                      <span>{count}</span>
+                {/* 次数分布ヒストグラム */}
+                <DegreeDistributionChart
+                  degreeDistribution={graphStatistics.degreeDistribution}
+                />
+
+                {/* 接続性指標 */}
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">
+                    接続性指標
+                  </div>
+                  <div className="flex flex-col gap-0.5 pl-2">
+                    <div>
+                      平均ホップ数:{" "}
+                      {graphStatistics.avgPathLength.toFixed(2)}
                     </div>
-                  ))}
+                    <div>直径: {graphStatistics.diameter}</div>
+                    <div>
+                      大域的クラスター係数:{" "}
+                      {graphStatistics.globalClusteringCoeff?.toFixed(3)}
+                    </div>
+                    <div>
+                      平均クラスター係数:{" "}
+                      {graphStatistics.avgClusteringCoeff?.toFixed(3)}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 重要エンティティ */}
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">
+                    重要エンティティ（ハブ）
+                  </div>
+                  <div className="flex flex-col gap-1 pl-2">
+                    {graphStatistics.topDegreeNodes.map((node) => (
+                      <button
+                        key={node.id}
+                        className="flex w-full cursor-pointer items-center justify-between rounded p-1 text-left hover:bg-white/10"
+                        onClick={() => setFocusNode(node)}
+                      >
+                        <span className="flex-1 truncate text-xs">
+                          {node.name}
+                        </span>
+                        <span className="ml-2 rounded bg-slate-600 px-1 text-xs">
+                          {node.degree}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* タイプ内訳 */}
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">
+                    ノードタイプ内訳
+                  </div>
+                  <div className="pl-2">
+                    {Object.entries(nodeTypeCounts).map(([type, count]) => (
+                      <div key={type} className="flex justify-between">
+                        <span>{type}</span>
+                        <span>{count}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <div className="font-semibold text-slate-400">
+                    エッジタイプ内訳
+                  </div>
+                  <div className="pl-2">
+                    {Object.entries(linkTypeCounts).map(([type, count]) => (
+                      <div key={type} className="flex justify-between">
+                        <span>{type}</span>
+                        <span>{count}</span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </DisclosurePanel>
             </Disclosure>
@@ -453,6 +514,81 @@ export const PropertiesSummaryPanel = ({
         ))}
       </div>
     </div>
+  );
+};
+
+const DEGREE_BINS = [
+  { label: "0", min: 0, max: 0 },
+  { label: "1", min: 1, max: 1 },
+  { label: "2", min: 2, max: 2 },
+  { label: "3-5", min: 3, max: 5 },
+  { label: "6-10", min: 6, max: 10 },
+  { label: "11-20", min: 11, max: 20 },
+  { label: "21-50", min: 21, max: 50 },
+  { label: "51+", min: 51, max: Infinity },
+] as const;
+
+function binDegreeDistribution(
+  distribution: Record<number, number>,
+): { label: string; count: number }[] {
+  const binned = DEGREE_BINS.map((bin) => ({ label: bin.label, count: 0 }));
+  for (const [degStr, count] of Object.entries(distribution)) {
+    const deg = Number(degStr);
+    const idx = DEGREE_BINS.findIndex((b) => deg >= b.min && deg <= b.max);
+    if (idx !== -1) binned[idx]!.count += count;
+  }
+  return binned.filter((b) => b.count > 0);
+}
+
+const DegreeDistributionChart = ({
+  degreeDistribution,
+}: {
+  degreeDistribution: Record<number, number>;
+}) => {
+  const entries = Object.entries(degreeDistribution);
+  if (entries.length === 0) return null;
+
+  const useBinning = entries.length > 20;
+
+  const bars = useBinning
+    ? binDegreeDistribution(degreeDistribution)
+    : entries
+        .map(([degree, count]) => ({ label: String(degree), count }))
+        .sort((a, b) => Number(a.label) - Number(b.label));
+
+  const maxCount = Math.max(...bars.map((b) => b.count));
+
+  return (
+    <Disclosure defaultOpen={false}>
+      <DisclosureButton className="group flex w-full flex-row items-center gap-2 text-sm text-slate-400">
+        <div className="group-data-[open]:rotate-90">
+          <TriangleRightIcon height={14} width={14} color="white" />
+        </div>
+        <div className="font-semibold">次数分布</div>
+      </DisclosureButton>
+      <DisclosurePanel className="flex flex-col gap-0.5 pl-6 pt-1">
+        {bars.map(({ label, count }) => (
+          <div key={label} className="flex items-center gap-1 text-xs">
+            <div className="w-8 text-right text-slate-400">{label}</div>
+            <div className="flex-1">
+              <div
+                className="h-3 rounded-sm bg-blue-400"
+                style={{
+                  width: `${(count / maxCount) * 100}%`,
+                  minWidth: count > 0 ? "2px" : undefined,
+                }}
+              />
+            </div>
+            <div className="w-8 text-slate-400">{count}</div>
+          </div>
+        ))}
+        {useBinning && (
+          <div className="mt-1 text-xs text-slate-500">
+            ※ 次数が多いためビン化して表示
+          </div>
+        )}
+      </DisclosurePanel>
+    </Disclosure>
   );
 };
 

--- a/src/app/_utils/kg/graph-analysis.ts
+++ b/src/app/_utils/kg/graph-analysis.ts
@@ -21,6 +21,12 @@ export interface GraphAnalysisResult {
     diameter: number;
     avgPathLength: number;
     clusteringCoeff: number;
+    avgDegree: number;
+    density: number;
+    degreeStdDev: number;
+    maxDegree: number;
+    hubDependencyRatio: number;
+    degreeDistribution: Record<number, number>;
   };
 
   // 属性分析
@@ -174,6 +180,12 @@ export function analyzeGraphStructure(
       diameter: stats.diameter,
       avgPathLength: stats.avgPathLength,
       clusteringCoeff: stats.avgClusteringCoeff,
+      avgDegree: stats.avgDegree,
+      density: stats.density,
+      degreeStdDev: stats.degreeStdDev,
+      maxDegree: stats.maxDegree,
+      hubDependencyRatio: stats.hubDependencyRatio,
+      degreeDistribution: stats.degreeDistribution,
     },
     attributes: {
       numericAttributes,
@@ -214,6 +226,11 @@ export function prepareAnalysisForLLM(
       summary: {
         nodeCount: analysis.structure.nodeCount,
         relationshipCount: analysis.structure.relationshipCount,
+        avgDegree: analysis.structure.avgDegree,
+        density: analysis.structure.density,
+        degreeStdDev: analysis.structure.degreeStdDev,
+        maxDegree: analysis.structure.maxDegree,
+        hubDependencyRatio: analysis.structure.hubDependencyRatio,
         nodeLabelDistribution: Object.entries(analysis.structure.nodeLabels)
           .sort((a, b) => b[1] - a[1])
           .slice(0, 10)
@@ -225,6 +242,7 @@ export function prepareAnalysisForLLM(
           .slice(0, 10)
           .reduce((acc, [type, count]) => ({ ...acc, [type]: count }), {}),
       },
+      degreeDistribution: analysis.structure.degreeDistribution,
       topCentralNodes: topNodes,
       usefulAttributes: {
         numeric: significantAttributes,
@@ -265,7 +283,13 @@ export function getAnalysisDataByFocus(
           centralityMetrics: {
             diameter: analysis.structure.diameter,
             avgPathLength: analysis.structure.avgPathLength,
+            avgDegree: analysis.structure.avgDegree,
+            density: analysis.structure.density,
+            degreeStdDev: analysis.structure.degreeStdDev,
+            maxDegree: analysis.structure.maxDegree,
+            hubDependencyRatio: analysis.structure.hubDependencyRatio,
           },
+          degreeDistribution: analysis.structure.degreeDistribution,
         },
         null,
         2,

--- a/src/app/_utils/kg/graph-statistics.ts
+++ b/src/app/_utils/kg/graph-statistics.ts
@@ -41,7 +41,7 @@ export function calculateGraphStatistics(graph: GraphDocumentForFrontend) {
       ? (2 * graphLinks.length) / (graphNodes.length * (graphNodes.length - 1))
       : 0;
 
-  const maxDegree = degreeValues.length > 0 ? Math.max(...degreeValues) : 0;
+  const maxDegree = degreeValues.reduce((max, d) => Math.max(max, d), 0);
 
   const degreeVariance =
     graphNodes.length > 0

--- a/src/app/_utils/kg/graph-statistics.ts
+++ b/src/app/_utils/kg/graph-statistics.ts
@@ -30,6 +30,36 @@ export function calculateGraphStatistics(graph: GraphDocumentForFrontend) {
     .slice(0, 5) // 上位5件
     .map((n) => ({ ...n, degree: degrees.get(n.id) ?? 0 }));
 
+  // 次数分布に関する指標
+  const degreeValues = Array.from(degrees.values());
+
+  const avgDegree =
+    graphNodes.length > 0 ? (2 * graphLinks.length) / graphNodes.length : 0;
+
+  const density =
+    graphNodes.length > 1
+      ? (2 * graphLinks.length) / (graphNodes.length * (graphNodes.length - 1))
+      : 0;
+
+  const maxDegree = degreeValues.length > 0 ? Math.max(...degreeValues) : 0;
+
+  const degreeVariance =
+    graphNodes.length > 0
+      ? degreeValues.reduce((sum, d) => sum + (d - avgDegree) ** 2, 0) /
+        graphNodes.length
+      : 0;
+  const degreeStdDev = Math.sqrt(degreeVariance);
+
+  const maxDegreeNode = topDegreeNodes[0] ?? null;
+
+  const hubDependencyRatio =
+    graphLinks.length > 0 ? maxDegree / (2 * graphLinks.length) : 0;
+
+  const degreeDistribution: Record<number, number> = {};
+  for (const d of degreeValues) {
+    degreeDistribution[d] = (degreeDistribution[d] ?? 0) + 1;
+  }
+
   // 2. 直径と平均ホップ数の計算
   const adj = new Map<string, string[]>();
   graphNodes.forEach((n) => adj.set(n.id, []));
@@ -119,5 +149,12 @@ export function calculateGraphStatistics(graph: GraphDocumentForFrontend) {
     avgPathLength,
     avgClusteringCoeff,
     globalClusteringCoeff,
+    avgDegree,
+    density,
+    degreeStdDev,
+    maxDegree,
+    maxDegreeNode,
+    hubDependencyRatio,
+    degreeDistribution,
   };
 }


### PR DESCRIPTION
## Summary
- グラフ統計情報パネルに次数分布関連の新指標（平均次数、密度、次数標準偏差、最大次数、ハブ依存度）を追加
- 次数分布を Tailwind CSS ベースの棒グラフで表示（20件超はビン化）
- LLM 分析用の `GraphAnalysisResult` とクリップボードコピー JSON にも新指標を反映

## Test plan
- [ ] `/topic-spaces/[id]` でグラフ統計パネルの「概要を表示」を開き、基本統計・次数分析・次数分布・接続性指標が表示されること
- [ ] クリップボードコピー JSON に `avgDegree`, `density`, `degreeStdDev`, `maxDegree`, `hubDependencyRatio`, `degreeDistribution` が含まれること
- [ ] 次数の種類が20を超えるグラフで次数分布がビン化表示されること


Made with [Cursor](https://cursor.com)