### PR TITLE
Add TopicSpace Google Drive sync (user OAuth + Picker)

### DIFF
--- a/docs/topic-space-drive-sync.md
+++ b/docs/topic-space-drive-sync.md
@@ -1,12 +1,12 @@
-# Google Drive 同期（TopicSpace）
+# Google Drive 同期（リポジトリ）
 
-ArsTraverse が TopicSpace 単位で Google Drive フォルダと同期し、`INPUT_DRIVE` 型の SourceDocument として知識グラフ化します。
+ArsTraverse がリポジトリ単位で Google Drive フォルダと同期し、`INPUT_DRIVE` 型の SourceDocument として知識グラフ化します。
 
 ## 認証方式
 
 ログイン中の **本人の Google アカウント** で Drive にアクセスします（ユーザー OAuth のみ）。
 
-1. TopicSpace 画面で **「Google Drive を連携」**（`/api/google-drive/connect`）
+1. リポジトリ画面で **「Google Drive を連携」**（`/api/google-drive/connect`）
 2. Google の同意画面で Drive 読み取りを許可
 3. **「フォルダを選ぶ」**（Google Picker）で同期フォルダを選択
 4. **「今すぐ同期」**
@@ -25,6 +25,7 @@ ArsTraverse が TopicSpace 単位で Google Drive フォルダと同期し、`IN
 | `NEXT_PUBLIC_BASE_URL` | OAuth コールバック URL のベース |
 | `NEXT_PUBLIC_GOOGLE_PICKER_API_KEY` | Google Picker 用 API キー |
 | `NEXT_PUBLIC_GOOGLE_APP_ID` | Google Cloud プロジェクト番号 |
+| `CRON_SECRET` | Vercel Cron 認証用（本番必須。Vercel が `Authorization: Bearer` で送信） |
 
 ## Google Cloud Console 設定
 

--- a/docs/topic-space-drive-sync.md
+++ b/docs/topic-space-drive-sync.md
@@ -1,0 +1,58 @@
+# Google Drive 同期（TopicSpace）
+
+ArsTraverse が TopicSpace 単位で Google Drive フォルダと同期し、`INPUT_DRIVE` 型の SourceDocument として知識グラフ化します。
+
+## 認証方式
+
+ログイン中の **本人の Google アカウント** で Drive にアクセスします（ユーザー OAuth のみ）。
+
+1. TopicSpace 画面で **「Google Drive を連携」**（`/api/google-drive/connect`）
+2. Google の同意画面で Drive 読み取りを許可
+3. **「フォルダを選ぶ」**（Google Picker）で同期フォルダを選択
+4. **「今すぐ同期」**
+
+- フォルダ ID の手入力不要
+- サービスアカウントへの共有不要
+- `UserGoogleDriveConnection` に refresh token を保存
+- Cron 同期は `configuredByUserId` の token を使用
+
+## 環境変数
+
+| 変数 | 説明 |
+|------|------|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | 既存 NextAuth 用（Drive 追加 OAuth にも使用） |
+| `NEXTAUTH_SECRET` | OAuth state 署名 |
+| `NEXT_PUBLIC_BASE_URL` | OAuth コールバック URL のベース |
+| `NEXT_PUBLIC_GOOGLE_PICKER_API_KEY` | Google Picker 用 API キー |
+| `NEXT_PUBLIC_GOOGLE_APP_ID` | Google Cloud プロジェクト番号 |
+
+## Google Cloud Console 設定
+
+1. **Drive API** を有効化
+2. OAuth クライアントの **承認済みリダイレクト URI** に追加:
+   - `https://<your-domain>/api/google-drive/callback`
+   - ローカル: `http://localhost:3000/api/google-drive/callback`
+3. OAuth 同意画面にスコープ `https://www.googleapis.com/auth/drive.readonly` を追加
+4. Picker 用に **API キー** を作成（HTTP リファラー制限推奨）
+
+## データモデル
+
+- `UserGoogleDriveConnection` — ユーザーごとの Drive refresh token
+- `TopicSpaceDriveSync.configuredByUserId` — OAuth 同期のトークン持ち主
+- `TopicSpaceDriveSync.driveFolderName` — Picker で選んだ表示名
+
+## MCP / CLI
+
+| 手段 | 説明 |
+|------|------|
+| `sync_topic_space_drive_folder` | Platform MCP で Drive 同期 |
+| `get_topic_space_drive_sync_status` | 同期設定・状態の確認 |
+| `npm run export:topic-space` | DB からグラフ JSON をエクスポート |
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|------|------|
+| Picker が開かない | `NEXT_PUBLIC_GOOGLE_PICKER_API_KEY` / `NEXT_PUBLIC_GOOGLE_APP_ID` を確認 |
+| 同期で token エラー | Drive 連携を解除して再連携 |
+| Cron が止まる | 設定者の token 失効 → 再連携 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "file-type": "^21.3.4",
         "formidable": "^3.5.1",
         "geist": "^1.3.0",
+        "googleapis": "^148.0.0",
         "graphology": "^0.26.0",
         "graphology-communities-louvain": "^2.0.2",
         "ignore": "^7.0.5",
@@ -6913,6 +6914,14 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7034,8 +7043,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "peer": true
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -8379,7 +8387,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -9802,6 +9809,91 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/geist": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
@@ -10021,6 +10113,84 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "148.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-148.0.0.tgz",
+      "integrity": "sha512-8PDG5VItm6E1TdZWDqtRrUJSlBcNwz0/MwCa6AL81y/RxPGXJRUwKqGZfCoVX1ZBbfr3I4NkDxBmeTyOAZSWqw==",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -10086,6 +10256,18 @@
       "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
       "peerDependencies": {
         "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/handlebars": {
@@ -10981,6 +11163,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -11208,6 +11401,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -11297,7 +11498,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -11308,7 +11508,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -14909,8 +15108,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -16653,6 +16851,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/use-composed-ref": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:e2e:ui": "playwright test --ui",
     "mcp:i": "sudo npx @modelcontextprotocol/inspector",
     "kg:align": "tsx scripts/kg-alignment-agent/index.ts",
+    "export:topic-space": "tsx scripts/export-topic-space-graph.ts",
     "supabase:ensure-buckets": "tsx scripts/ensure-supabase-storage-buckets.ts"
   },
   "dependencies": {
@@ -63,6 +64,7 @@
     "file-type": "^21.3.4",
     "formidable": "^3.5.1",
     "geist": "^1.3.0",
+    "googleapis": "^148.0.0",
     "graphology": "^0.26.0",
     "graphology-communities-louvain": "^2.0.2",
     "ignore": "^7.0.5",

--- a/prisma/migrations/20260608120000_add_drive_sync/migration.sql
+++ b/prisma/migrations/20260608120000_add_drive_sync/migration.sql
@@ -1,0 +1,32 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'INPUT_DRIVE';
+
+-- AlterTable
+ALTER TABLE "SourceDocument" ADD COLUMN "externalSourceId" TEXT,
+ADD COLUMN "externalModifiedAt" TIMESTAMP(3),
+ADD COLUMN "contentHash" TEXT;
+
+-- CreateIndex
+CREATE INDEX "SourceDocument_externalSourceId_idx" ON "SourceDocument"("externalSourceId");
+
+-- CreateTable
+CREATE TABLE "TopicSpaceDriveSync" (
+    "id" TEXT NOT NULL,
+    "topicSpaceId" TEXT NOT NULL,
+    "driveFolderId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "recursive" BOOLEAN NOT NULL DEFAULT true,
+    "lastSyncedAt" TIMESTAMP(3),
+    "lastSyncStatus" TEXT,
+    "lastSyncError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TopicSpaceDriveSync_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TopicSpaceDriveSync_topicSpaceId_key" ON "TopicSpaceDriveSync"("topicSpaceId");
+
+-- AddForeignKey
+ALTER TABLE "TopicSpaceDriveSync" ADD CONSTRAINT "TopicSpaceDriveSync_topicSpaceId_fkey" FOREIGN KEY ("topicSpaceId") REFERENCES "TopicSpace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260608140000_user_google_drive_oauth/migration.sql
+++ b/prisma/migrations/20260608140000_user_google_drive_oauth/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable TopicSpaceDriveSync
+ALTER TABLE "TopicSpaceDriveSync" ADD COLUMN "driveFolderName" TEXT,
+ADD COLUMN "authMode" TEXT NOT NULL DEFAULT 'user_oauth',
+ADD COLUMN "configuredByUserId" TEXT;
+
+-- CreateTable
+CREATE TABLE "UserGoogleDriveConnection" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "refreshToken" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserGoogleDriveConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserGoogleDriveConnection_userId_key" ON "UserGoogleDriveConnection"("userId");
+
+-- AddForeignKey
+ALTER TABLE "TopicSpaceDriveSync" ADD CONSTRAINT "TopicSpaceDriveSync_configuredByUserId_fkey" FOREIGN KEY ("configuredByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "UserGoogleDriveConnection" ADD CONSTRAINT "UserGoogleDriveConnection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,9 @@ model User {
   reviewingEdits       GraphEditProposal[] @relation("GraphEditProposalReviewer")
   lockedProposals      GraphEditProposal[] @relation("GraphEditProposalLock")
   proposalComments     ProposalComment[]
+
+  googleDriveConnection UserGoogleDriveConnection?
+  configuredDriveSyncs  TopicSpaceDriveSync[] @relation("DriveSyncConfiguredBy")
   
   createdAt            DateTime             @default(now())
   updatedAt            DateTime             @updatedAt
@@ -101,9 +104,15 @@ model SourceDocument {
   updatedAt DateTime @updatedAt
   isDeleted Boolean  @default(false)
   documentType DocumentType @default(INPUT_TXT)
+  /// Google Drive fileId 等の外部ストレージ ID（INPUT_DRIVE 時の取得キー）
+  externalSourceId String?
+  externalModifiedAt DateTime?
+  contentHash String?
 
   user   User   @relation(fields: [userId], references: [id])
   userId String
+
+  @@index([externalSourceId])
 
   graph       DocumentGraph?
   topicSpaces TopicSpace[]
@@ -117,6 +126,7 @@ enum DocumentType {
   INPUT_PDF
   INPUT_TXT
   INPUT_SCAN
+  INPUT_DRIVE
 }
 
 model DocumentGraph {
@@ -229,6 +239,39 @@ model TopicSpace {
   edgeProvenances TopicSpaceDocumentEdgeProvenance[]
   // ドキュメントアタッチ時のノード対応（detach 時に共有ノードを残すため）
   nodeProvenances TopicSpaceDocumentNodeProvenance[]
+
+  driveSync TopicSpaceDriveSync?
+}
+
+model TopicSpaceDriveSync {
+  id                 String    @id @default(cuid())
+  topicSpaceId       String    @unique
+  driveFolderId      String
+  driveFolderName    String?
+  authMode           String    @default("user_oauth") // 常に user_oauth（レガシー列）
+  configuredByUserId String?
+  enabled            Boolean   @default(true)
+  recursive          Boolean   @default(true)
+  lastSyncedAt       DateTime?
+  lastSyncStatus     String?   // idle | running | error
+  lastSyncError      String?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  topicSpace     TopicSpace @relation(fields: [topicSpaceId], references: [id], onDelete: Cascade)
+  configuredBy   User?      @relation("DriveSyncConfiguredBy", fields: [configuredByUserId], references: [id], onDelete: SetNull)
+}
+
+model UserGoogleDriveConnection {
+  id           String    @id @default(cuid())
+  userId       String    @unique
+  refreshToken String
+  scope        String
+  expiresAt    DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model TopicSpaceDocumentEdgeProvenance {

--- a/scripts/export-topic-space-graph.ts
+++ b/scripts/export-topic-space-graph.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env tsx
+/**
+ * TopicSpace グラフを DB から直接エクスポート（MCP get_topic_space_graph と同形式）。
+ *
+ * Usage:
+ *   npm run export:topic-space -- --topic-space-id=<id> [--out=path.json]
+ *
+ * Environment:
+ *   DATABASE_URL (required)
+ */
+import { writeFileSync } from "node:fs";
+import { PrismaClient } from "@prisma/client";
+import { mcpGetTopicSpaceGraph } from "../src/server/mcp/platform-handlers";
+
+function parseArgs(argv: string[]) {
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg?.startsWith("--")) continue;
+    const body = arg.slice(2);
+    const eq = body.indexOf("=");
+    if (eq !== -1) {
+      args[body.slice(0, eq)] = body.slice(eq + 1);
+    } else if (argv[i + 1] && !argv[i + 1]!.startsWith("--")) {
+      args[body] = argv[++i]!;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const topicSpaceId = args["topic-space-id"]?.trim();
+  const outPath = args.out?.trim();
+  const userId = args["user-id"]?.trim();
+
+  if (!topicSpaceId) {
+    console.error("Usage: npm run export:topic-space -- --topic-space-id=<id> [--out=file.json] [--user-id=<adminUserId>]");
+    process.exit(1);
+  }
+
+  const db = new PrismaClient();
+  try {
+    let adminUserId = userId;
+    if (!adminUserId) {
+      const topicSpace = await db.topicSpace.findFirst({
+        where: { id: topicSpaceId, isDeleted: false },
+        include: { admins: { select: { id: true }, take: 1 } },
+      });
+      adminUserId = topicSpace?.admins[0]?.id;
+    }
+
+    if (!adminUserId) {
+      throw new Error("TopicSpace 管理者が見つかりません。--user-id を指定してください。");
+    }
+
+    const exported = await mcpGetTopicSpaceGraph(
+      { db, userId: adminUserId },
+      { topicSpaceId },
+    );
+
+    const snapshot = {
+      version: "1.0",
+      exportedAt: new Date().toISOString(),
+      source: {
+        topicSpaceId: exported.topicSpaceId,
+        topicSpaceName: exported.topicSpaceName,
+        mcpToolIdentifier: exported.mcpToolIdentifier,
+        sourceDocumentIds: exported.sourceDocumentIds,
+      },
+      stats: {
+        nodeCount: exported.nodeCount,
+        relationshipCount: exported.relationshipCount,
+      },
+      provenance: exported.provenance,
+      nodes: exported.graph.nodes,
+      relationships: exported.graph.relationships,
+    };
+
+    const json = JSON.stringify(snapshot, null, 2);
+    if (outPath) {
+      writeFileSync(outPath, json, "utf-8");
+      console.log(`Wrote ${outPath} (${exported.nodeCount} nodes, ${exported.relationshipCount} rels)`);
+    } else {
+      process.stdout.write(json);
+    }
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/_components/topic-space/document-attach-modal.tsx
+++ b/src/app/_components/topic-space/document-attach-modal.tsx
@@ -44,6 +44,9 @@ const emptyDocument: DocumentResponse = {
   updatedAt: new Date(),
   isDeleted: false,
   documentType: "INPUT_TXT",
+  externalSourceId: null,
+  externalModifiedAt: null,
+  contentHash: null,
 };
 
 export const DocumentAttachModal = ({

--- a/src/app/_components/topic-space/google-drive-folder-picker.tsx
+++ b/src/app/_components/topic-space/google-drive-folder-picker.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/trpc/react";
+
+type PickedFolder = {
+  id: string;
+  name: string;
+};
+
+type GoogleDriveFolderPickerProps = {
+  disabled?: boolean;
+  onPick: (folder: PickedFolder) => void;
+};
+
+type PickerDocument = {
+  id: string;
+  name: string;
+  mimeType?: string;
+};
+
+type PickerResponse = {
+  action: string;
+  docs?: PickerDocument[];
+};
+
+declare global {
+  interface Window {
+    gapi?: {
+      load: (name: string, callback: () => void) => void;
+    };
+    google?: {
+      picker: {
+        Action: { PICKED: string };
+        DocsView: new (viewId?: string) => unknown;
+        PickerBuilder: new () => unknown;
+        ViewId: { FOLDERS: string };
+      };
+    };
+  }
+}
+
+function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+      resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.body.appendChild(script);
+  });
+}
+
+export function GoogleDriveFolderPicker({
+  disabled,
+  onPick,
+}: GoogleDriveFolderPickerProps) {
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pickerConfigQuery = api.googleDrive.getPickerConfig.useQuery(undefined, {
+    enabled: false,
+    retry: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        await loadScript("https://apis.google.com/js/api.js");
+        if (cancelled) return;
+        window.gapi?.load("picker", () => {
+          if (!cancelled) setReady(true);
+        });
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Picker の読み込みに失敗しました",
+          );
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openPicker = useCallback(async () => {
+    setError(null);
+    const result = await pickerConfigQuery.refetch();
+    const config = result.data;
+    const picker = window.google?.picker;
+
+    if (!config || !picker || !ready) {
+      setError("Google Picker の準備ができていません");
+      return;
+    }
+
+    const view = new picker.DocsView(picker.ViewId.FOLDERS);
+    (view as { setIncludeFolders: (v: boolean) => void }).setIncludeFolders(true);
+    (view as { setSelectFolderEnabled: (v: boolean) => void }).setSelectFolderEnabled(true);
+
+    const builder = new picker.PickerBuilder();
+    const chain = builder as {
+      addView: (v: unknown) => typeof chain;
+      setOAuthToken: (token: string) => typeof chain;
+      setDeveloperKey: (key: string) => typeof chain;
+      setAppId: (appId: string) => typeof chain;
+      setTitle: (title: string) => typeof chain;
+      setCallback: (callback: (data: PickerResponse) => void) => typeof chain;
+      build: () => { setVisible: (visible: boolean) => void };
+    };
+
+    const pickerInstance = chain
+      .addView(view)
+      .setOAuthToken(config.accessToken)
+      .setDeveloperKey(config.apiKey)
+      .setAppId(config.appId)
+      .setTitle("同期するフォルダを選択")
+      .setCallback((data: PickerResponse) => {
+        if (data.action !== picker.Action.PICKED || !data.docs?.[0]) return;
+        const doc = data.docs[0];
+        onPick({ id: doc.id, name: doc.name });
+      })
+      .build();
+
+    pickerInstance.setVisible(true);
+  }, [onPick, pickerConfigQuery, ready]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        disabled={(disabled ?? false) || !ready || pickerConfigQuery.isFetching}
+        onClick={() => void openPicker()}
+        className="rounded bg-blue-600 px-3 py-1 text-xs hover:bg-blue-500 disabled:opacity-50"
+      >
+        {pickerConfigQuery.isFetching ? "準備中..." : "フォルダを選ぶ"}
+      </button>
+      {(error ?? pickerConfigQuery.error?.message) && (
+        <p className="text-xs text-red-400">
+          {error ?? pickerConfigQuery.error?.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/topic-space/google-drive-folder-picker.tsx
+++ b/src/app/_components/topic-space/google-drive-folder-picker.tsx
@@ -27,7 +27,12 @@ type PickerResponse = {
 declare global {
   interface Window {
     gapi?: {
-      load: (name: string, callback: () => void) => void;
+      load: (
+        name: string,
+        optionsOrCallback:
+          | { callback?: () => void; onerror?: () => void }
+          | (() => void),
+      ) => void;
     };
     google?: {
       picker: {
@@ -40,20 +45,79 @@ declare global {
   }
 }
 
-function loadScript(src: string): Promise<void> {
+const GAPI_SCRIPT_URL = "https://apis.google.com/js/api.js";
+const GAPI_READY_TIMEOUT_MS = 15_000;
+
+function waitForGapi(
+  timeoutMs = GAPI_READY_TIMEOUT_MS,
+): Promise<NonNullable<Window["gapi"]>> {
   return new Promise((resolve, reject) => {
-    const existing = document.querySelector(`script[src="${src}"]`);
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      if (window.gapi?.load) {
+        window.clearInterval(timer);
+        resolve(window.gapi);
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        window.clearInterval(timer);
+        reject(new Error("Google API (gapi) の読み込みがタイムアウトしました。広告ブロック等でスクリプトが遮断されている可能性があります。"));
+      }
+    }, 50);
+  });
+}
+
+function loadGapiScript(): Promise<void> {
+  if (window.gapi?.load) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const startWaiting = () => {
+      void waitForGapi()
+        .then(() => resolve())
+        .catch(reject);
+    };
+
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${GAPI_SCRIPT_URL}"]`,
+    );
     if (existing) {
-      resolve();
+      startWaiting();
       return;
     }
+
     const script = document.createElement("script");
-    script.src = src;
+    script.src = GAPI_SCRIPT_URL;
     script.async = true;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    script.onload = startWaiting;
+    script.onerror = () =>
+      reject(new Error("Google API スクリプトの読み込みに失敗しました"));
     document.body.appendChild(script);
   });
+}
+
+function loadPickerModule(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!window.gapi?.load) {
+      reject(new Error("Google API (gapi) が未ロードです"));
+      return;
+    }
+
+    window.gapi.load("picker", {
+      callback: () => resolve(),
+      onerror: () =>
+        reject(new Error("Google Picker API の読み込みに失敗しました")),
+    });
+  });
+}
+
+async function ensurePickerReady(): Promise<void> {
+  await loadGapiScript();
+  await waitForGapi();
+  if (!window.google?.picker) {
+    await loadPickerModule();
+  }
 }
 
 export function GoogleDriveFolderPicker({
@@ -61,6 +125,7 @@ export function GoogleDriveFolderPicker({
   onPick,
 }: GoogleDriveFolderPickerProps) {
   const [ready, setReady] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const pickerConfigQuery = api.googleDrive.getPickerConfig.useQuery(undefined, {
     enabled: false,
@@ -70,12 +135,13 @@ export function GoogleDriveFolderPicker({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      setLoading(true);
+      setError(null);
       try {
-        await loadScript("https://apis.google.com/js/api.js");
-        if (cancelled) return;
-        window.gapi?.load("picker", () => {
-          if (!cancelled) setReady(true);
-        });
+        await ensurePickerReady();
+        if (!cancelled) {
+          setReady(true);
+        }
       } catch (loadError) {
         if (!cancelled) {
           setError(
@@ -83,6 +149,10 @@ export function GoogleDriveFolderPicker({
               ? loadError.message
               : "Picker の読み込みに失敗しました",
           );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
         }
       }
     })();
@@ -93,11 +163,25 @@ export function GoogleDriveFolderPicker({
 
   const openPicker = useCallback(async () => {
     setError(null);
+    try {
+      if (!ready) {
+        await ensurePickerReady();
+        setReady(true);
+      }
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Picker の読み込みに失敗しました",
+      );
+      return;
+    }
+
     const result = await pickerConfigQuery.refetch();
     const config = result.data;
     const picker = window.google?.picker;
 
-    if (!config || !picker || !ready) {
+    if (!config || !picker) {
       setError("Google Picker の準備ができていません");
       return;
     }
@@ -137,11 +221,13 @@ export function GoogleDriveFolderPicker({
     <div className="flex flex-col gap-1">
       <button
         type="button"
-        disabled={(disabled ?? false) || !ready || pickerConfigQuery.isFetching}
+        disabled={(disabled ?? false) || loading || pickerConfigQuery.isFetching}
         onClick={() => void openPicker()}
         className="rounded bg-blue-600 px-3 py-1 text-xs hover:bg-blue-500 disabled:opacity-50"
       >
-        {pickerConfigQuery.isFetching ? "準備中..." : "フォルダを選ぶ"}
+        {loading || pickerConfigQuery.isFetching
+          ? "準備中..."
+          : "フォルダを選ぶ"}
       </button>
       {(error ?? pickerConfigQuery.error?.message) && (
         <p className="text-xs text-red-400">

--- a/src/app/_components/topic-space/topic-graph-detail.tsx
+++ b/src/app/_components/topic-space/topic-graph-detail.tsx
@@ -19,6 +19,7 @@ import { Switch } from "@headlessui/react";
 import { useSession } from "next-auth/react";
 import { MultiDocumentGraphDetailViewer } from "../view/graph-view/multi-document-graph-detail-viewer";
 import { TopicSpaceDocumentListSection } from "./document-list-section";
+import { TopicSpaceDriveSyncPanel } from "./topic-space-drive-sync-panel";
 
 export const circlePosition = (
   index: number,
@@ -216,6 +217,13 @@ export const TopicGraphDetail = ({
                 <></>
               )}
             </div>
+
+            {session && (
+              <TopicSpaceDriveSyncPanel
+                topicSpaceId={id}
+                onSynced={() => void refetch()}
+              />
+            )}
 
             <TopicSpaceDocumentListSection
               documents={topicSpace.sourceDocuments as DocumentResponse[]}

--- a/src/app/_components/topic-space/topic-space-detail.tsx
+++ b/src/app/_components/topic-space/topic-space-detail.tsx
@@ -25,6 +25,7 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
 import { TopicSpaceChangeHistory } from "./topic-space-change-history";
 import { ProposalList } from "../graph-edit-proposal/proposal-list";
 import { MemberListModal } from "./member-list-modal";
+import { TopicSpaceDriveSyncPanel } from "./topic-space-drive-sync-panel";
 
 export const TopicSpaceDetail = ({ id }: { id: string }) => {
   // 変更履歴のハイライト情報を管理
@@ -108,6 +109,11 @@ export const TopicSpaceDetail = ({ id }: { id: string }) => {
                 );
               })}
             </div>
+
+            <TopicSpaceDriveSyncPanel
+              topicSpaceId={id}
+              onSynced={() => void refetch()}
+            />
 
             <div className="flex flex-row items-center justify-between">
               <div className="flex flex-row items-center justify-start gap-4 py-2">

--- a/src/app/_components/topic-space/topic-space-detail.tsx
+++ b/src/app/_components/topic-space/topic-space-detail.tsx
@@ -10,6 +10,7 @@ import {
   Pencil2Icon,
   PersonIcon,
   PlusIcon,
+  ShareIcon,
   StarIcon,
   TrashIcon,
 } from "../icons";
@@ -110,11 +111,6 @@ export const TopicSpaceDetail = ({ id }: { id: string }) => {
               })}
             </div>
 
-            <TopicSpaceDriveSyncPanel
-              topicSpaceId={id}
-              onSynced={() => void refetch()}
-            />
-
             <div className="flex flex-row items-center justify-between">
               <div className="flex flex-row items-center justify-start gap-4 py-2">
                 <button
@@ -183,6 +179,19 @@ export const TopicSpaceDetail = ({ id }: { id: string }) => {
                       <FileTextIcon width={16} height={16} color="white" />
                     </div>
                     <div className="text-sm">ドキュメント</div>
+                  </div>
+                )}
+              </Tab>
+              <Tab as={Fragment}>
+                {({ hover, selected }) => (
+                  <div
+                    className={`flex cursor-pointer flex-row items-center gap-1 rounded-t-sm px-3 py-2 text-sm font-semibold ${selected ? "border-b-2 border-white outline-none" : ""
+                      } ${hover ? "bg-white/10" : ""}`}
+                  >
+                    <div className="h-4 w-4">
+                      <ShareIcon width={16} height={16} color="white" />
+                    </div>
+                    <div className="text-sm">Drive 同期</div>
                   </div>
                 )}
               </Tab>
@@ -269,6 +278,12 @@ export const TopicSpaceDetail = ({ id }: { id: string }) => {
                     }}
                   />
                 </div>
+              </TabPanel>
+              <TabPanel>
+                <TopicSpaceDriveSyncPanel
+                  topicSpaceId={id}
+                  onSynced={() => void refetch()}
+                />
               </TabPanel>
               <TabPanel>
                 <ProposalList topicSpaceId={id} />

--- a/src/app/_components/topic-space/topic-space-drive-sync-panel.tsx
+++ b/src/app/_components/topic-space/topic-space-drive-sync-panel.tsx
@@ -65,7 +65,7 @@ export function TopicSpaceDriveSyncPanel({
     <div className="flex flex-col gap-3 rounded-md border border-slate-700/60 bg-slate-900/30 p-3">
       <div className="text-sm font-semibold">Google Drive 同期</div>
       <p className="text-xs text-slate-400">
-        ログイン中の Google アカウントの Drive フォルダを選び、資料を TopicSpace
+        ログイン中の Google アカウントの Drive フォルダを選び、資料をリポジトリ
         に取り込みます。
       </p>
 
@@ -157,7 +157,7 @@ export function TopicSpaceDriveSyncPanel({
       </div>
 
       {status?.lastSyncedAt && (
-        <div className="text-xs text-slate-400">
+        <div className="text-xs text-slate-400" suppressHydrationWarning>
           最終同期: {new Date(status.lastSyncedAt).toLocaleString("ja-JP")}
           {status.lastSyncStatus ? ` (${status.lastSyncStatus})` : ""}
         </div>

--- a/src/app/_components/topic-space/topic-space-drive-sync-panel.tsx
+++ b/src/app/_components/topic-space/topic-space-drive-sync-panel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { api } from "@/trpc/react";
+import { GoogleDriveFolderPicker } from "./google-drive-folder-picker";
+
+type TopicSpaceDriveSyncPanelProps = {
+  topicSpaceId: string;
+  onSynced?: () => void;
+};
+
+export function TopicSpaceDriveSyncPanel({
+  topicSpaceId,
+  onSynced,
+}: TopicSpaceDriveSyncPanelProps) {
+  const pathname = usePathname();
+  const statusQuery = api.topicSpaces.getDriveSyncStatus.useQuery({
+    id: topicSpaceId,
+  });
+  const driveConnectionQuery = api.googleDrive.getConnectionStatus.useQuery();
+  const upsertConfig = api.topicSpaces.upsertDriveSyncConfig.useMutation({
+    onSuccess: () => void statusQuery.refetch(),
+  });
+  const syncDrive = api.topicSpaces.syncDriveFolder.useMutation({
+    onSuccess: () => {
+      void statusQuery.refetch();
+      onSynced?.();
+    },
+  });
+  const disconnectDrive = api.googleDrive.disconnect.useMutation({
+    onSuccess: () => {
+      void driveConnectionQuery.refetch();
+      void statusQuery.refetch();
+    },
+  });
+
+  const [folderName, setFolderName] = useState("");
+  const [recursive, setRecursive] = useState(true);
+
+  const status = statusQuery.data;
+  const driveConnection = driveConnectionQuery.data;
+  const isBusy =
+    upsertConfig.isPending || syncDrive.isPending || disconnectDrive.isPending;
+
+  useEffect(() => {
+    if (status?.driveFolderName) setFolderName(status.driveFolderName);
+    if (status?.recursive !== undefined) setRecursive(status.recursive);
+  }, [status?.driveFolderName, status?.recursive]);
+
+  const connectUrl = `/api/google-drive/connect?returnTo=${encodeURIComponent(pathname)}`;
+
+  const saveFolder = (folder: { id: string; name: string }) => {
+    setFolderName(folder.name);
+    upsertConfig.mutate({
+      id: topicSpaceId,
+      driveFolderId: folder.id,
+      driveFolderName: folder.name,
+      enabled: true,
+      recursive,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-slate-700/60 bg-slate-900/30 p-3">
+      <div className="text-sm font-semibold">Google Drive 同期</div>
+      <p className="text-xs text-slate-400">
+        ログイン中の Google アカウントの Drive フォルダを選び、資料を TopicSpace
+        に取り込みます。
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        {driveConnection?.connected ? (
+          <>
+            <span className="text-emerald-400">Drive 連携済み</span>
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={() => disconnectDrive.mutate()}
+              className="text-slate-400 underline hover:text-slate-200"
+            >
+              連携解除
+            </button>
+          </>
+        ) : (
+          <a
+            href={connectUrl}
+            className="rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-500"
+          >
+            Google Drive を連携
+          </a>
+        )}
+      </div>
+
+      {driveConnection?.connected && (
+        <div className="flex flex-col gap-2 rounded border border-slate-700/50 p-2">
+          <div className="text-xs text-slate-300">
+            {folderName || status?.driveFolderName
+              ? `選択中: ${folderName || status?.driveFolderName}`
+              : "同期フォルダ未選択"}
+          </div>
+          <GoogleDriveFolderPicker
+            disabled={isBusy}
+            onPick={saveFolder}
+          />
+        </div>
+      )}
+
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={recursive}
+          onChange={(event) => setRecursive(event.target.checked)}
+        />
+        サブフォルダも再帰的に同期
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        {status?.configured && (
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={() =>
+              upsertConfig.mutate({
+                id: topicSpaceId,
+                driveFolderId: status.driveFolderId!,
+                driveFolderName: folderName
+                  ? folderName
+                  : (status.driveFolderName ?? undefined),
+                enabled: true,
+                recursive,
+              })
+            }
+            className="rounded bg-slate-700 px-3 py-1 text-xs hover:bg-slate-600 disabled:opacity-50"
+          >
+            設定を保存
+          </button>
+        )}
+        <button
+          type="button"
+          disabled={isBusy || !status?.configured}
+          onClick={() => syncDrive.mutate({ id: topicSpaceId })}
+          className="rounded bg-orange-600 px-3 py-1 text-xs hover:bg-orange-500 disabled:opacity-50"
+        >
+          {syncDrive.isPending ? "同期中..." : "今すぐ同期"}
+        </button>
+        {status?.driveFolderUrl && (
+          <a
+            href={status.driveFolderUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded border border-slate-600 px-3 py-1 text-xs hover:bg-slate-800"
+          >
+            フォルダを開く
+          </a>
+        )}
+      </div>
+
+      {status?.lastSyncedAt && (
+        <div className="text-xs text-slate-400">
+          最終同期: {new Date(status.lastSyncedAt).toLocaleString("ja-JP")}
+          {status.lastSyncStatus ? ` (${status.lastSyncStatus})` : ""}
+        </div>
+      )}
+      {status?.lastSyncError && (
+        <div className="text-xs text-red-400">{status.lastSyncError}</div>
+      )}
+      {syncDrive.data && (
+        <div className="text-xs text-emerald-400">
+          作成 {syncDrive.data.created} / 更新 {syncDrive.data.updated} / スキップ{" "}
+          {syncDrive.data.skipped} / 削除 {syncDrive.data.detached}
+        </div>
+      )}
+      {(upsertConfig.error ?? syncDrive.error ?? disconnectDrive.error) && (
+        <div className="text-xs text-red-400">
+          {(upsertConfig.error ?? syncDrive.error ?? disconnectDrive.error)?.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/_utils/text/text.ts
+++ b/src/app/_utils/text/text.ts
@@ -7,6 +7,13 @@ import { BUCKETS } from "../supabase/const";
 
 const require = createRequire(import.meta.url);
 
+type GetTextOptions = {
+  externalSourceId?: string | null;
+  mimeType?: string | null;
+  fileName?: string | null;
+  ocrMetadata?: unknown;
+};
+
 type PdfParseResult = { text: string };
 
 async function extractPdfTextFromLocalFile(filePath: string): Promise<string> {
@@ -22,13 +29,27 @@ async function extractPdfTextFromLocalFile(filePath: string): Promise<string> {
 export const getTextFromDocumentFile = async (
   url: string,
   type: DocumentType,
+  options?: GetTextOptions,
 ) => {
   const trimmedUrl = url.trim();
-  if (!trimmedUrl) {
+  if (!trimmedUrl && type !== DocumentType.INPUT_DRIVE) {
     throw new Error("ドキュメント URL が空です");
   }
 
+  if (type === DocumentType.INPUT_DRIVE) {
+    throw new Error(
+      "INPUT_DRIVE の本文取得は resolveSourceDocumentPlainText を使用してください",
+    );
+  }
+
   if (type === DocumentType.INPUT_PDF) {
+    const fileId = options?.externalSourceId?.trim();
+    if (fileId) {
+      throw new Error(
+        "Drive 由来 PDF の本文取得は resolveSourceDocumentPlainText を使用してください",
+      );
+    }
+
     const localFilePath = await writeLocalFileFromUrl(trimmedUrl, "input.pdf");
     return extractPdfTextFromLocalFile(localFilePath);
   }

--- a/src/app/api/cron/topic-space-drive-sync/route.ts
+++ b/src/app/api/cron/topic-space-drive-sync/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { db } from "@/server/db";
+import { syncAllEnabledTopicSpaceDriveFolders } from "@/server/services/kg/sync-topic-space-drive.service";
+
+export const maxDuration = 300;
+export const revalidate = 0;
+
+export const GET = async () => {
+  try {
+    const results = await syncAllEnabledTopicSpaceDriveFolders(db);
+    return NextResponse.json({
+      message: "Drive sync completed",
+      topicSpaceCount: results.length,
+      results,
+    });
+  } catch (error) {
+    console.error("Drive sync cron failed:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Drive sync cron failed",
+      },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/cron/topic-space-drive-sync/route.ts
+++ b/src/app/api/cron/topic-space-drive-sync/route.ts
@@ -1,11 +1,29 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@/server/db";
 import { syncAllEnabledTopicSpaceDriveFolders } from "@/server/services/kg/sync-topic-space-drive.service";
 
 export const maxDuration = 300;
 export const revalidate = 0;
 
-export const GET = async () => {
+function isAuthorizedCron(request: NextRequest): boolean {
+  if (process.env.NODE_ENV !== "production") {
+    return true;
+  }
+
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  if (!cronSecret) {
+    console.error("CRON_SECRET is not configured");
+    return false;
+  }
+
+  return request.headers.get("authorization") === `Bearer ${cronSecret}`;
+}
+
+export const GET = async (request: NextRequest) => {
+  if (!isAuthorizedCron(request)) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
   try {
     const results = await syncAllEnabledTopicSpaceDriveFolders(db);
     return NextResponse.json({

--- a/src/app/api/google-drive/callback/route.ts
+++ b/src/app/api/google-drive/callback/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { db } from "@/server/db";
+import {
+  createGoogleOAuth2Client,
+  upsertUserGoogleDriveConnection,
+} from "@/server/lib/google-drive/user-oauth";
+import {
+  GOOGLE_DRIVE_READONLY_SCOPE,
+  sanitizeReturnTo,
+  verifyGoogleDriveOAuthState,
+} from "@/server/lib/google-drive/oauth-state";
+
+export const GET = async (request: Request) => {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const oauthError = url.searchParams.get("error");
+
+  if (oauthError) {
+    return NextResponse.redirect(
+      new URL(
+        `/topic-spaces?drive_error=${encodeURIComponent(oauthError)}`,
+        request.url,
+      ),
+    );
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(
+      new URL("/topic-spaces?drive_error=missing_code", request.url),
+    );
+  }
+
+  try {
+    const { userId, returnTo } = verifyGoogleDriveOAuthState(state);
+    const client = createGoogleOAuth2Client();
+    const { tokens } = await client.getToken(code);
+
+    if (!tokens.refresh_token) {
+      return NextResponse.redirect(
+        new URL(
+          `${sanitizeReturnTo(returnTo)}?drive_error=missing_refresh_token`,
+          request.url,
+        ),
+      );
+    }
+
+    await upsertUserGoogleDriveConnection(db, {
+      userId,
+      refreshToken: tokens.refresh_token,
+      scope: tokens.scope ?? GOOGLE_DRIVE_READONLY_SCOPE,
+      expiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+    });
+
+    const redirectUrl = new URL(sanitizeReturnTo(returnTo), request.url);
+    redirectUrl.searchParams.set("drive_connected", "1");
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "drive_oauth_failed";
+    return NextResponse.redirect(
+      new URL(
+        `/topic-spaces?drive_error=${encodeURIComponent(message)}`,
+        request.url,
+      ),
+    );
+  }
+};

--- a/src/app/api/google-drive/connect/route.ts
+++ b/src/app/api/google-drive/connect/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getServerAuthSession } from "@/server/auth";
+import {
+  sanitizeReturnTo,
+  signGoogleDriveOAuthState,
+} from "@/server/lib/google-drive/oauth-state";
+import { buildGoogleDriveConnectUrl } from "@/server/lib/google-drive/user-oauth";
+
+export const GET = async (request: Request) => {
+  const session = await getServerAuthSession();
+  if (!session?.user?.id) {
+    return NextResponse.redirect(new URL("/api/auth/signin", request.url));
+  }
+
+  const url = new URL(request.url);
+  const returnTo = sanitizeReturnTo(url.searchParams.get("returnTo"));
+
+  const state = signGoogleDriveOAuthState({
+    userId: session.user.id,
+    returnTo,
+  });
+
+  const connectUrl = buildGoogleDriveConnectUrl({
+    userId: session.user.id,
+    returnTo,
+    state,
+  });
+
+  return NextResponse.redirect(connectUrl);
+};

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -17,6 +17,8 @@ import {
   mcpGetTopicSpaceChangeHistory,
   mcpGetTopicSpaceChangeHistoryDetail,
   mcpReplayNodeMergesFromHistory,
+  mcpGetTopicSpaceDriveSyncStatus,
+  mcpSyncTopicSpaceDriveFolder,
 } from "@/server/mcp/platform-handlers";
 
 const AUTH_REQUIRED_MESSAGE =
@@ -181,6 +183,66 @@ create_topic_space_from_source_documents の後、ローカル JSON へ保存す
           return formatMcpToolError(
             error,
             "TopicSpace グラフの取得中にエラーが発生しました。",
+          );
+        }
+      },
+    );
+
+    server.tool(
+      "get_topic_space_drive_sync_status",
+      `TopicSpace に設定された Google Drive 同期の状態を返します。
+Drive フォルダ ID、最終同期日時、エラー有無を確認する用途に使えます。`,
+      {
+        topicSpaceId: z.string().min(1).describe("対象 TopicSpace ID"),
+      },
+      async ({ topicSpaceId }) => {
+        try {
+          const result = await mcpGetTopicSpaceDriveSyncStatus(
+            requirePlatformCtx(draftCtx),
+            { topicSpaceId },
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          return formatMcpToolError(
+            error,
+            "Drive 同期状態の取得中にエラーが発生しました。",
+          );
+        }
+      },
+    );
+
+    server.tool(
+      "sync_topic_space_drive_folder",
+      `TopicSpace に紐づく Google Drive フォルダを同期し、新規・更新ファイルを SourceDocument（INPUT_DRIVE）として取り込み、KG 抽出後に TopicSpace へ統合します。
+設定者の Google Drive 連携（user OAuth）と TopicSpace のフォルダ設定が必要です。`,
+      {
+        topicSpaceId: z.string().min(1).describe("同期対象 TopicSpace ID"),
+      },
+      async ({ topicSpaceId }) => {
+        try {
+          const result = await mcpSyncTopicSpaceDriveFolder(
+            requirePlatformCtx(draftCtx),
+            { topicSpaceId },
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          return formatMcpToolError(
+            error,
+            "Drive 同期の実行中にエラーが発生しました。",
           );
         }
       },

--- a/src/app/mcp/authorize/_components/mcp-authorize-panel.tsx
+++ b/src/app/mcp/authorize/_components/mcp-authorize-panel.tsx
@@ -74,8 +74,8 @@ export function McpAuthorizePanel({
           スコープ:{" "}
           <span className="text-white">
             {result.scope === "platform"
-              ? "プラットフォーム（ドキュメント・TopicSpace 作成）"
-              : "TopicSpace（検索・グラフ編集）"}
+              ? "プラットフォーム（ドキュメント・リポジトリ作成）"
+              : "リポジトリ（検索・グラフ編集）"}
           </span>
           <br />
           有効期限:{" "}
@@ -97,7 +97,7 @@ export function McpAuthorizePanel({
         {result.mcpUrl ? (
           <>
             <label className="mt-6 block text-xs font-medium uppercase tracking-wide text-slate-400">
-              TopicSpace MCP URL
+              リポジトリ MCP URL
             </label>
             <CopyBlock value={result.mcpUrl} />
           </>
@@ -173,17 +173,17 @@ export function McpAuthorizePanel({
             className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white"
           >
             <option value={PLATFORM_MCP_SCOPE}>
-              プラットフォーム（ドキュメント取り込み・TopicSpace 新規作成）
+              プラットフォーム（ドキュメント取り込み・リポジトリ新規作成）
             </option>
             {topicSpaces.map((space) => (
               <option key={space.id} value={space.id}>
-                TopicSpace: {space.name}
+                リポジトリ: {space.name}
               </option>
             ))}
           </select>
           <p className="mt-2 text-xs leading-relaxed text-slate-500">
-            初回取り込みでは「プラットフォーム」を選び、TopicSpace
-            作成後に TopicSpace を含むトークンを再発行してください。
+            初回取り込みでは「プラットフォーム」を選び、リポジトリ
+            作成後にリポジトリを含むトークンを再発行してください。
           </p>
         </div>
 

--- a/src/app/mcp/authorize/actions.ts
+++ b/src/app/mcp/authorize/actions.ts
@@ -43,7 +43,7 @@ export async function issueMcpAccessToken(input: {
     if (!topicSpace) {
       return {
         ok: false,
-        error: "TopicSpace が見つからないか、アクセス権限がありません。",
+        error: "リポジトリが見つからないか、アクセス権限がありません。",
       };
     }
   }

--- a/src/env.js
+++ b/src/env.js
@@ -32,6 +32,7 @@ export const env = createEnv({
     QUICK_COMMONS_TOPICSPACE_ID: z.string().optional(),
     QUICK_COMMONS_SYSTEM_USER_ID: z.string().optional(),
     QUICK_COMMONS_ALLOWED_ORIGIN: z.string().optional(),
+    CRON_SECRET: z.string().optional(),
     /** Server-side Storage upload (MCP, scan flow). Local: `supabase status` fallback when URL is 127.0.0.1 */
     SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
   },
@@ -71,6 +72,7 @@ export const env = createEnv({
     QUICK_COMMONS_TOPICSPACE_ID: process.env.QUICK_COMMONS_TOPICSPACE_ID,
     QUICK_COMMONS_SYSTEM_USER_ID: process.env.QUICK_COMMONS_SYSTEM_USER_ID,
     QUICK_COMMONS_ALLOWED_ORIGIN: process.env.QUICK_COMMONS_ALLOWED_ORIGIN,
+    CRON_SECRET: process.env.CRON_SECRET,
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
     NEXT_PUBLIC_GOOGLE_PICKER_API_KEY:
       process.env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY,

--- a/src/env.js
+++ b/src/env.js
@@ -42,7 +42,8 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
-    // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_GOOGLE_PICKER_API_KEY: z.string().optional(),
+    NEXT_PUBLIC_GOOGLE_APP_ID: z.string().optional(),
     NEXT_PUBLIC_SUPABASE_URL: z.string(),
     NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
     NEXT_PUBLIC_BASE_URL: z.string(),
@@ -71,6 +72,9 @@ export const env = createEnv({
     QUICK_COMMONS_SYSTEM_USER_ID: process.env.QUICK_COMMONS_SYSTEM_USER_ID,
     QUICK_COMMONS_ALLOWED_ORIGIN: process.env.QUICK_COMMONS_ALLOWED_ORIGIN,
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    NEXT_PUBLIC_GOOGLE_PICKER_API_KEY:
+      process.env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY,
+    NEXT_PUBLIC_GOOGLE_APP_ID: process.env.NEXT_PUBLIC_GOOGLE_APP_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -18,6 +18,7 @@ import { imageRouter } from "./routers/image";
 import { storyRouter } from "./routers/story";
 import { printRouter } from "./routers/print";
 import { scanRouter } from "./routers/scan";
+import { googleDriveRouter } from "./routers/google-drive";
 
 /**
  * This is the primary router for your server.
@@ -44,6 +45,7 @@ export const appRouter = createTRPCRouter({
   story: storyRouter,
   print: printRouter,
   scan: scanRouter,
+  googleDrive: googleDriveRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/annotation.ts
+++ b/src/server/api/routers/annotation.ts
@@ -928,7 +928,7 @@ export const annotationRouter = createTRPCRouter({
         if (!topicSpace) {
           throw new TRPCError({
             code: "NOT_FOUND",
-            message: "TopicSpaceが見つかりません",
+            message: "リポジトリが見つかりません",
           });
         }
 
@@ -944,7 +944,7 @@ export const annotationRouter = createTRPCRouter({
           if (!node) {
             throw new TRPCError({
               code: "BAD_REQUEST",
-              message: "指定されたノードはこのTopicSpaceに属していません",
+              message: "指定されたノードはこのリポジトリに属していません",
             });
           }
         }
@@ -961,7 +961,7 @@ export const annotationRouter = createTRPCRouter({
             throw new TRPCError({
               code: "BAD_REQUEST",
               message:
-                "指定されたリレーションシップはこのTopicSpaceに属していません",
+                "指定されたリレーションシップはこのリポジトリに属していません",
             });
           }
         }

--- a/src/server/api/routers/document-graph.ts
+++ b/src/server/api/routers/document-graph.ts
@@ -55,8 +55,11 @@ export const documentGraphRouter = createTRPCRouter({
           ...graph.sourceDocument,
           text: await resolveSourceDocumentPlainText({
             url: graph.sourceDocument.url,
+            name: graph.sourceDocument.name,
+            userId: graph.sourceDocument.userId,
             documentType: graph.sourceDocument.documentType,
             ocrMetadata: graph.sourceDocument.ocrMetadata,
+            externalSourceId: graph.sourceDocument.externalSourceId,
           }),
         },
       };

--- a/src/server/api/routers/google-drive.ts
+++ b/src/server/api/routers/google-drive.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+import { env } from "@/env";
+import {
+  getUserGoogleDriveAccessToken,
+  hasUserGoogleDriveConnection,
+} from "@/server/lib/google-drive/user-oauth";
+
+export const googleDriveRouter = createTRPCRouter({
+  getConnectionStatus: protectedProcedure.query(async ({ ctx }) => {
+    const connected = await hasUserGoogleDriveConnection(
+      ctx.db,
+      ctx.session.user.id,
+    );
+    const connection = connected
+      ? await ctx.db.userGoogleDriveConnection.findUnique({
+          where: { userId: ctx.session.user.id },
+          select: { scope: true, expiresAt: true, updatedAt: true },
+        })
+      : null;
+
+    return {
+      connected,
+      scope: connection?.scope ?? null,
+      expiresAt: connection?.expiresAt?.toISOString() ?? null,
+      updatedAt: connection?.updatedAt?.toISOString() ?? null,
+    };
+  }),
+
+  disconnect: protectedProcedure.mutation(async ({ ctx }) => {
+    await ctx.db.userGoogleDriveConnection.deleteMany({
+      where: { userId: ctx.session.user.id },
+    });
+    return { success: true };
+  }),
+
+  getPickerConfig: protectedProcedure.query(async ({ ctx }) => {
+    const accessToken = await getUserGoogleDriveAccessToken(
+      ctx.db,
+      ctx.session.user.id,
+    );
+
+    const apiKey = env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY?.trim();
+    const appId = env.NEXT_PUBLIC_GOOGLE_APP_ID?.trim();
+
+    if (!apiKey || !appId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "NEXT_PUBLIC_GOOGLE_PICKER_API_KEY と NEXT_PUBLIC_GOOGLE_APP_ID を設定してください。",
+      });
+    }
+
+    return {
+      accessToken,
+      apiKey,
+      appId,
+      clientId: env.GOOGLE_CLIENT_ID,
+    };
+  }),
+});

--- a/src/server/api/routers/graph-edit-proposal.ts
+++ b/src/server/api/routers/graph-edit-proposal.ts
@@ -429,7 +429,7 @@ export const graphEditProposalRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpaceが見つかりません",
+          message: "リポジトリが見つかりません",
         });
       }
 
@@ -440,7 +440,7 @@ export const graphEditProposalRouter = createTRPCRouter({
       if (!isAdmin) {
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "このTopicSpaceの変更提案を閲覧する権限がありません",
+          message: "このリポジトリの変更提案を閲覧する権限がありません",
         });
       }
 
@@ -993,7 +993,7 @@ export const graphEditProposalRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpaceが見つかりません",
+          message: "リポジトリが見つかりません",
         });
       }
 
@@ -1004,7 +1004,7 @@ export const graphEditProposalRouter = createTRPCRouter({
       if (!isAdmin) {
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "このTopicSpaceの変更履歴を閲覧する権限がありません",
+          message: "このリポジトリの変更履歴を閲覧する権限がありません",
         });
       }
 

--- a/src/server/api/routers/kg-integration.ts
+++ b/src/server/api/routers/kg-integration.ts
@@ -69,7 +69,7 @@ export const integrationProcedures = {
           },
         });
         if (!topicSpace) {
-          throw new Error("TopicSpace not found");
+          throw new Error("リポジトリが見つかりません");
         }
 
         graphData = {

--- a/src/server/api/routers/source-document.ts
+++ b/src/server/api/routers/source-document.ts
@@ -63,8 +63,11 @@ export const getTextReference = async (
 
   const fullText = await resolveSourceDocumentPlainText({
     url: document.url,
+    name: document.name,
+    userId: document.userId,
     documentType: document.documentType,
     ocrMetadata: document.ocrMetadata,
+    externalSourceId: document.externalSourceId,
   });
 
   console.log("fullText: ", fullText.slice(0, 20));
@@ -136,8 +139,11 @@ export const sourceDocumentRouter = createTRPCRouter({
         ),
         text: await resolveSourceDocumentPlainText({
           url: document.url,
+          name: document.name,
+          userId: document.userId,
           documentType: document.documentType,
           ocrMetadata: document.ocrMetadata,
+          externalSourceId: document.externalSourceId,
         }),
       };
     }),

--- a/src/server/api/routers/story.ts
+++ b/src/server/api/routers/story.ts
@@ -48,7 +48,7 @@ export const storyRouter = createTRPCRouter({
       });
 
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
 
       // データをDB構造に変換

--- a/src/server/api/routers/topic-space.ts
+++ b/src/server/api/routers/topic-space.ts
@@ -33,6 +33,7 @@ import {
 import { attachDocumentsToTopicSpace } from "@/server/services/kg/attach-documents.service";
 import { detachDocumentsFromTopicSpace } from "@/server/services/kg/detach-documents.service";
 import { mergeGraphNodes as mergeGraphNodesService } from "@/server/services/kg/merge-graph-nodes.service";
+import { syncTopicSpaceDriveFolder } from "@/server/services/kg/sync-topic-space-drive.service";
 import { updateTopicSpaceGraph } from "@/server/services/kg/update-topic-space-graph.service";
 import { updateTopicSpaceGraphProperties } from "@/server/services/kg/update-topic-space-graph-properties.service";
 import { getTextReference } from "./source-document";
@@ -40,6 +41,8 @@ import { KnowledgeGraphInputSchema } from "../schemas/knowledge-graph";
 import { BUCKETS } from "@/app/_utils/supabase/const";
 import { storageUtils } from "@/app/_utils/supabase/supabase";
 import { TRPCError } from "@trpc/server";
+import { buildDriveFolderUrl } from "@/server/lib/google-drive/urls";
+import { hasUserGoogleDriveConnection } from "@/server/lib/google-drive/user-oauth";
 import OpenAI from "openai";
 
 const TopicSpaceCreateSchema = z.object({
@@ -529,10 +532,16 @@ export const topicSpaceRouter = createTRPCRouter({
       }
       const mimeMatch = header?.match(/^data:(image\/[a-zA-Z+.-]+);base64$/);
       const mime = mimeMatch?.[1];
-      if (!mime || !ALLOWED_IMAGE_MIMES.includes(mime as (typeof ALLOWED_IMAGE_MIMES)[number])) {
+      if (
+        !mime ||
+        !ALLOWED_IMAGE_MIMES.includes(
+          mime as (typeof ALLOWED_IMAGE_MIMES)[number],
+        )
+      ) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Only image/jpeg, image/png, image/webp, image/gif are allowed",
+          message:
+            "Only image/jpeg, image/png, image/webp, image/gif are allowed",
         });
       }
 
@@ -727,5 +736,111 @@ ${referenceText}
           isComplete: true,
         };
       }
+    }),
+
+  getDriveSyncStatus: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const topicSpace = await ctx.db.topicSpace.findFirst({
+        where: { id: input.id, isDeleted: false },
+        include: { admins: true, driveSync: true },
+      });
+      if (!topicSpace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "TopicSpace not found",
+        });
+      }
+      assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
+
+      const driveSync = topicSpace.driveSync;
+      const userDriveConnected = await hasUserGoogleDriveConnection(
+        ctx.db,
+        ctx.session.user.id,
+      );
+
+      return {
+        configured: Boolean(driveSync),
+        enabled: driveSync?.enabled ?? false,
+        driveFolderId: driveSync?.driveFolderId ?? null,
+        driveFolderName: driveSync?.driveFolderName ?? null,
+        driveFolderUrl: driveSync?.driveFolderId
+          ? buildDriveFolderUrl(driveSync.driveFolderId)
+          : null,
+        configuredByUserId: driveSync?.configuredByUserId ?? null,
+        recursive: driveSync?.recursive ?? true,
+        lastSyncedAt: driveSync?.lastSyncedAt?.toISOString() ?? null,
+        lastSyncStatus: driveSync?.lastSyncStatus ?? null,
+        lastSyncError: driveSync?.lastSyncError ?? null,
+        userDriveConnected,
+        canUsePicker: userDriveConnected,
+      };
+    }),
+
+  upsertDriveSyncConfig: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        driveFolderId: z.string().min(1),
+        driveFolderName: z.string().optional(),
+        enabled: z.boolean().default(true),
+        recursive: z.boolean().default(true),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const topicSpace = await findTopicSpaceWithGraph(ctx.db, input.id);
+      if (!topicSpace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "TopicSpace not found",
+        });
+      }
+      assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
+
+      const connected = await hasUserGoogleDriveConnection(
+        ctx.db,
+        ctx.session.user.id,
+      );
+      if (!connected) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Google Drive が未連携です。先に Drive を連携してください。",
+        });
+      }
+
+      const driveSync = await ctx.db.topicSpaceDriveSync.upsert({
+        where: { topicSpaceId: input.id },
+        create: {
+          topicSpaceId: input.id,
+          driveFolderId: input.driveFolderId.trim(),
+          driveFolderName: input.driveFolderName?.trim() ?? null,
+          authMode: "user_oauth",
+          configuredByUserId: ctx.session.user.id,
+          enabled: input.enabled,
+          recursive: input.recursive,
+        },
+        update: {
+          driveFolderId: input.driveFolderId.trim(),
+          driveFolderName: input.driveFolderName?.trim() ?? null,
+          authMode: "user_oauth",
+          configuredByUserId: ctx.session.user.id,
+          enabled: input.enabled,
+          recursive: input.recursive,
+        },
+      });
+
+      return {
+        driveFolderId: driveSync.driveFolderId,
+        driveFolderName: driveSync.driveFolderName,
+        driveFolderUrl: buildDriveFolderUrl(driveSync.driveFolderId),
+        enabled: driveSync.enabled,
+        recursive: driveSync.recursive,
+      };
+    }),
+
+  syncDriveFolder: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      return syncTopicSpaceDriveFolder(ctx, { topicSpaceId: input.id });
     }),
 });

--- a/src/server/api/routers/topic-space.ts
+++ b/src/server/api/routers/topic-space.ts
@@ -153,7 +153,7 @@ export const topicSpaceRouter = createTRPCRouter({
       });
 
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
 
@@ -185,7 +185,7 @@ export const topicSpaceRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
 
@@ -219,7 +219,7 @@ export const topicSpaceRouter = createTRPCRouter({
           tags: true,
         },
       });
-      if (!topicSpace) throw new Error("TopicSpace not found");
+      if (!topicSpace) throw new Error("リポジトリが見つかりません");
 
       return formTopicSpaceForFrontendPublic(
         {
@@ -252,7 +252,7 @@ export const topicSpaceRouter = createTRPCRouter({
           tags: true,
         },
       });
-      if (!topicSpace) throw new Error("TopicSpace not found");
+      if (!topicSpace) throw new Error("リポジトリが見つかりません");
 
       const graphData = {
         nodes: topicSpace.graphNodes,
@@ -355,7 +355,7 @@ export const topicSpaceRouter = createTRPCRouter({
       });
 
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
 
@@ -379,7 +379,7 @@ export const topicSpaceRouter = createTRPCRouter({
       });
 
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
 
@@ -405,7 +405,7 @@ export const topicSpaceRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
@@ -453,7 +453,7 @@ export const topicSpaceRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
@@ -518,7 +518,7 @@ export const topicSpaceRouter = createTRPCRouter({
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
@@ -602,7 +602,7 @@ export const topicSpaceRouter = createTRPCRouter({
         },
       });
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
 
@@ -645,7 +645,7 @@ export const topicSpaceRouter = createTRPCRouter({
       });
 
       if (!topicSpace) {
-        throw new Error("TopicSpace not found");
+        throw new Error("リポジトリが見つかりません");
       }
       // ログインユーザーであれば誰でもノード説明生成が可能
 
@@ -748,7 +748,7 @@ ${referenceText}
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
@@ -792,7 +792,7 @@ ${referenceText}
       if (!topicSpace) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "TopicSpace not found",
+          message: "リポジトリが見つかりません",
         });
       }
       assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);

--- a/src/server/api/routers/tree-graph.ts
+++ b/src/server/api/routers/tree-graph.ts
@@ -22,7 +22,7 @@ export const treeGraphRouter = createTRPCRouter({
         },
       });
 
-      if (!topicSpace) throw new Error("TopicSpace not found");
+      if (!topicSpace) throw new Error("リポジトリが見つかりません");
 
       const topicSpaceGraphData = {
         nodes: topicSpace.graphNodes,

--- a/src/server/lib/google-drive/fetch-document-text.ts
+++ b/src/server/lib/google-drive/fetch-document-text.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { DocumentType } from "@prisma/client";
+import type { drive_v3 } from "googleapis";
+
+export type DriveFileMeta = {
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime: string;
+  md5Checksum?: string | null;
+  webViewLink?: string | null;
+};
+
+const TEXT_MIME_TYPES = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/x-markdown",
+  "application/json",
+]);
+
+const GOOGLE_DOC_MIME = "application/vnd.google-apps.document";
+
+export function isSyncableDriveMimeType(mimeType: string): boolean {
+  return (
+    mimeType === GOOGLE_DOC_MIME ||
+    mimeType === "application/pdf" ||
+    TEXT_MIME_TYPES.has(mimeType) ||
+    mimeType.startsWith("text/")
+  );
+}
+
+export function resolveDocumentTypeFromDriveMime(mimeType: string): DocumentType {
+  if (mimeType === "application/pdf") {
+    return DocumentType.INPUT_PDF;
+  }
+  return DocumentType.INPUT_DRIVE;
+}
+
+export function computeDriveContentHash(meta: DriveFileMeta, body: string): string {
+  const basis = [
+    meta.id,
+    meta.modifiedTime,
+    meta.md5Checksum ?? "",
+    body.length.toString(),
+    createHash("sha256").update(body).digest("hex"),
+  ].join("|");
+  return createHash("sha256").update(basis).digest("hex");
+}
+
+export async function listDriveFilesInFolder(
+  input: {
+    folderId: string;
+    recursive: boolean;
+  },
+  driveClient: drive_v3.Drive,
+): Promise<DriveFileMeta[]> {
+  const drive = driveClient;
+  const files: DriveFileMeta[] = [];
+  const queue = [input.folderId];
+
+  while (queue.length > 0) {
+    const currentFolderId = queue.shift();
+    if (!currentFolderId) continue;
+
+    let pageToken: string | undefined;
+    do {
+      const response = await drive.files.list({
+        q: `'${currentFolderId}' in parents and trashed = false`,
+        fields:
+          "nextPageToken, files(id, name, mimeType, modifiedTime, md5Checksum, webViewLink)",
+        pageSize: 100,
+        pageToken,
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
+      });
+
+      for (const file of response.data.files ?? []) {
+        if (!file.id || !file.name || !file.mimeType || !file.modifiedTime) {
+          continue;
+        }
+
+        if (file.mimeType === "application/vnd.google-apps.folder") {
+          if (input.recursive) {
+            queue.push(file.id);
+          }
+          continue;
+        }
+
+        if (!isSyncableDriveMimeType(file.mimeType)) {
+          continue;
+        }
+
+        files.push({
+          id: file.id,
+          name: file.name,
+          mimeType: file.mimeType,
+          modifiedTime: file.modifiedTime,
+          md5Checksum: file.md5Checksum,
+          webViewLink: file.webViewLink,
+        });
+      }
+
+      pageToken = response.data.nextPageToken ?? undefined;
+    } while (pageToken);
+  }
+
+  return files;
+}
+
+export async function fetchDriveFileText(
+  meta: DriveFileMeta,
+  driveClient: drive_v3.Drive,
+): Promise<string> {
+  const drive = driveClient;
+
+  if (meta.mimeType === GOOGLE_DOC_MIME) {
+    const response = await drive.files.export(
+      { fileId: meta.id, mimeType: "text/plain" },
+      { responseType: "text" },
+    );
+    const text = typeof response.data === "string" ? response.data : "";
+    return text.trim();
+  }
+
+  if (meta.mimeType === "application/pdf") {
+    const response = await drive.files.get(
+      { fileId: meta.id, alt: "media" },
+      { responseType: "arraybuffer" },
+    );
+    const buffer = Buffer.from(response.data as ArrayBuffer);
+    const { createRequire } = await import("module");
+    const require = createRequire(import.meta.url);
+    const pdfParse = require("pdf-parse/lib/pdf-parse.js") as (
+      data: Buffer,
+    ) => Promise<{ text: string }>;
+    const parsed = await pdfParse(buffer);
+    return parsed.text.trim();
+  }
+
+  const response = await drive.files.get(
+    { fileId: meta.id, alt: "media" },
+    { responseType: "text" },
+  );
+  const text = typeof response.data === "string" ? response.data : "";
+  return text.trim();
+}

--- a/src/server/lib/google-drive/fetch-document-text.ts
+++ b/src/server/lib/google-drive/fetch-document-text.ts
@@ -57,6 +57,7 @@ export async function listDriveFilesInFolder(
   const drive = driveClient;
   const files: DriveFileMeta[] = [];
   const queue = [input.folderId];
+  const visited = new Set<string>([input.folderId]);
 
   while (queue.length > 0) {
     const currentFolderId = queue.shift();
@@ -80,7 +81,8 @@ export async function listDriveFilesInFolder(
         }
 
         if (file.mimeType === "application/vnd.google-apps.folder") {
-          if (input.recursive) {
+          if (input.recursive && !visited.has(file.id)) {
+            visited.add(file.id);
             queue.push(file.id);
           }
           continue;

--- a/src/server/lib/google-drive/oauth-state.ts
+++ b/src/server/lib/google-drive/oauth-state.ts
@@ -72,10 +72,11 @@ export function verifyGoogleDriveOAuthState(state: string): {
 }
 
 export function sanitizeReturnTo(returnTo: string | null): string {
-  if (!returnTo?.startsWith("/")) {
+  if (!returnTo) {
     return "/topic-spaces";
   }
-  if (returnTo.startsWith("//")) {
+  // 先頭が単一の '/' で、2文字目が '/' や '\' でない相対パスのみ許可
+  if (!/^\/[^/\\]/.test(returnTo) && returnTo !== "/") {
     return "/topic-spaces";
   }
   return returnTo;

--- a/src/server/lib/google-drive/oauth-state.ts
+++ b/src/server/lib/google-drive/oauth-state.ts
@@ -1,0 +1,82 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const GOOGLE_DRIVE_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/drive.readonly";
+
+type OAuthStatePayload = {
+  userId: string;
+  returnTo: string;
+  nonce: string;
+};
+
+function getStateSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET?.trim();
+  if (!secret) {
+    throw new Error("NEXTAUTH_SECRET が未設定です");
+  }
+  return secret;
+}
+
+export function signGoogleDriveOAuthState(input: {
+  userId: string;
+  returnTo: string;
+}): string {
+  const payload: OAuthStatePayload = {
+    userId: input.userId,
+    returnTo: input.returnTo,
+    nonce: randomBytes(16).toString("hex"),
+  };
+  const body = JSON.stringify(payload);
+  const signature = createHmac("sha256", getStateSecret())
+    .update(body)
+    .digest("hex");
+  return Buffer.from(JSON.stringify({ body, signature })).toString("base64url");
+}
+
+export function verifyGoogleDriveOAuthState(state: string): {
+  userId: string;
+  returnTo: string;
+} {
+  let parsed: { body?: string; signature?: string };
+  try {
+    parsed = JSON.parse(
+      Buffer.from(state, "base64url").toString("utf8"),
+    ) as { body?: string; signature?: string };
+  } catch {
+    throw new Error("無効な OAuth state です");
+  }
+
+  if (!parsed.body || !parsed.signature) {
+    throw new Error("無効な OAuth state です");
+  }
+
+  const expected = createHmac("sha256", getStateSecret())
+    .update(parsed.body)
+    .digest("hex");
+
+  const actualBuffer = Buffer.from(parsed.signature, "hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  if (
+    actualBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(actualBuffer, expectedBuffer)
+  ) {
+    throw new Error("OAuth state の署名が一致しません");
+  }
+
+  const payload = JSON.parse(parsed.body) as OAuthStatePayload;
+  if (!payload.userId || !payload.returnTo) {
+    throw new Error("OAuth state の内容が不正です");
+  }
+
+  return { userId: payload.userId, returnTo: payload.returnTo };
+}
+
+export function sanitizeReturnTo(returnTo: string | null): string {
+  if (!returnTo?.startsWith("/")) {
+    return "/topic-spaces";
+  }
+  if (returnTo.startsWith("//")) {
+    return "/topic-spaces";
+  }
+  return returnTo;
+}

--- a/src/server/lib/google-drive/source-metadata.ts
+++ b/src/server/lib/google-drive/source-metadata.ts
@@ -1,0 +1,29 @@
+export type DriveSourceMetadata = {
+  drive?: {
+    fileId: string;
+    mimeType: string;
+    folderId?: string;
+  };
+};
+
+export function buildDriveSourceMetadata(input: {
+  fileId: string;
+  mimeType: string;
+  folderId?: string;
+}): DriveSourceMetadata {
+  return {
+    drive: {
+      fileId: input.fileId,
+      mimeType: input.mimeType,
+      folderId: input.folderId,
+    },
+  };
+}
+
+export function readDriveMimeType(
+  ocrMetadata: unknown,
+): string | undefined {
+  if (!ocrMetadata || typeof ocrMetadata !== "object") return undefined;
+  const drive = (ocrMetadata as DriveSourceMetadata).drive;
+  return drive?.mimeType;
+}

--- a/src/server/lib/google-drive/sync-client.ts
+++ b/src/server/lib/google-drive/sync-client.ts
@@ -1,0 +1,30 @@
+import type { PrismaClient, TopicSpaceDriveSync } from "@prisma/client";
+import type { drive_v3 } from "googleapis";
+import { getGoogleDriveClientForUser } from "./user-oauth";
+
+export async function getDriveClientForTopicSpaceSync(
+  db: PrismaClient,
+  driveSync: TopicSpaceDriveSync,
+): Promise<drive_v3.Drive> {
+  const userId = driveSync.configuredByUserId;
+  if (!userId) {
+    throw new Error(
+      "Drive 同期の設定者が未登録です。Drive を連携してフォルダを選び直してください。",
+    );
+  }
+
+  return getGoogleDriveClientForUser(db, userId);
+}
+
+export async function isDriveSyncAvailable(
+  db: PrismaClient,
+  driveSync?: Pick<TopicSpaceDriveSync, "configuredByUserId"> | null,
+): Promise<boolean> {
+  if (!driveSync?.configuredByUserId) return false;
+
+  const connection = await db.userGoogleDriveConnection.findUnique({
+    where: { userId: driveSync.configuredByUserId },
+    select: { id: true },
+  });
+  return Boolean(connection);
+}

--- a/src/server/lib/google-drive/urls.ts
+++ b/src/server/lib/google-drive/urls.ts
@@ -1,0 +1,7 @@
+export function buildDriveWebViewUrl(fileId: string): string {
+  return `https://drive.google.com/file/d/${fileId}/view`;
+}
+
+export function buildDriveFolderUrl(folderId: string): string {
+  return `https://drive.google.com/drive/folders/${folderId}`;
+}

--- a/src/server/lib/google-drive/user-oauth.ts
+++ b/src/server/lib/google-drive/user-oauth.ts
@@ -66,7 +66,7 @@ export async function getUserGoogleDriveAccessToken(
 
   if (!connection?.refreshToken) {
     throw new Error(
-      "Google Drive が未連携です。TopicSpace 画面から Drive を連携してください。",
+      "Google Drive が未連携です。リポジトリ画面から Drive を連携してください。",
     );
   }
 
@@ -101,7 +101,7 @@ export async function getGoogleDriveClientForUser(
 
   if (!connection?.refreshToken) {
     throw new Error(
-      "Google Drive が未連携です。TopicSpace 画面から Drive を連携してください。",
+      "Google Drive が未連携です。リポジトリ画面から Drive を連携してください。",
     );
   }
 

--- a/src/server/lib/google-drive/user-oauth.ts
+++ b/src/server/lib/google-drive/user-oauth.ts
@@ -1,0 +1,125 @@
+import type { PrismaClient } from "@prisma/client";
+import { google } from "googleapis";
+import { env } from "@/env";
+import { GOOGLE_DRIVE_READONLY_SCOPE } from "./oauth-state";
+
+export function getGoogleOAuthRedirectUri(): string {
+  const base = env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, "");
+  return `${base}/api/google-drive/callback`;
+}
+
+export function createGoogleOAuth2Client() {
+  return new google.auth.OAuth2(
+    env.GOOGLE_CLIENT_ID,
+    env.GOOGLE_CLIENT_SECRET,
+    getGoogleOAuthRedirectUri(),
+  );
+}
+
+export function buildGoogleDriveConnectUrl(input: {
+  userId: string;
+  returnTo: string;
+  state: string;
+}): string {
+  const client = createGoogleOAuth2Client();
+  return client.generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent",
+    scope: [GOOGLE_DRIVE_READONLY_SCOPE],
+    state: input.state,
+    include_granted_scopes: true,
+  });
+}
+
+export async function upsertUserGoogleDriveConnection(
+  db: PrismaClient,
+  input: {
+    userId: string;
+    refreshToken: string;
+    scope: string;
+    expiresAt: Date | null;
+  },
+) {
+  return db.userGoogleDriveConnection.upsert({
+    where: { userId: input.userId },
+    create: {
+      userId: input.userId,
+      refreshToken: input.refreshToken,
+      scope: input.scope,
+      expiresAt: input.expiresAt,
+    },
+    update: {
+      refreshToken: input.refreshToken,
+      scope: input.scope,
+      expiresAt: input.expiresAt,
+    },
+  });
+}
+
+export async function getUserGoogleDriveAccessToken(
+  db: PrismaClient,
+  userId: string,
+): Promise<string> {
+  const connection = await db.userGoogleDriveConnection.findUnique({
+    where: { userId },
+  });
+
+  if (!connection?.refreshToken) {
+    throw new Error(
+      "Google Drive が未連携です。TopicSpace 画面から Drive を連携してください。",
+    );
+  }
+
+  const client = createGoogleOAuth2Client();
+  client.setCredentials({
+    refresh_token: connection.refreshToken,
+  });
+
+  const { credentials } = await client.refreshAccessToken();
+  const accessToken = credentials.access_token;
+  if (!accessToken) {
+    throw new Error("Google Drive アクセストークンの更新に失敗しました");
+  }
+
+  if (credentials.expiry_date) {
+    await db.userGoogleDriveConnection.update({
+      where: { userId },
+      data: { expiresAt: new Date(credentials.expiry_date) },
+    });
+  }
+
+  return accessToken;
+}
+
+export async function getGoogleDriveClientForUser(
+  db: PrismaClient,
+  userId: string,
+) {
+  const connection = await db.userGoogleDriveConnection.findUnique({
+    where: { userId },
+  });
+
+  if (!connection?.refreshToken) {
+    throw new Error(
+      "Google Drive が未連携です。TopicSpace 画面から Drive を連携してください。",
+    );
+  }
+
+  const client = createGoogleOAuth2Client();
+  client.setCredentials({
+    refresh_token: connection.refreshToken,
+  });
+
+  return google.drive({ version: "v3", auth: client });
+}
+
+export async function hasUserGoogleDriveConnection(
+  db: PrismaClient,
+  userId: string,
+): Promise<boolean> {
+  const connection = await db.userGoogleDriveConnection.findUnique({
+    where: { userId },
+    select: { id: true },
+  });
+  return Boolean(connection);
+}

--- a/src/server/mcp/platform-handlers.ts
+++ b/src/server/mcp/platform-handlers.ts
@@ -229,7 +229,7 @@ export async function mcpCreateSourceDocumentFromPlainText(
     relationshipCount: graph.relationships.length,
     graph,
     message:
-      "SourceDocument を作成し、LLM による知識グラフ抽出を完了しました。TopicSpace を作成する場合は create_topic_space_from_source_documents を使用してください。",
+      "SourceDocument を作成し、LLM による知識グラフ抽出を完了しました。リポジトリを作成する場合は create_topic_space_from_source_documents を使用してください。",
   };
 }
 
@@ -265,7 +265,7 @@ export async function mcpCreateTopicSpaceFromSourceDocuments(
     relationshipCount: result.relationshipCount,
     linkedDocuments: result.linkedDocuments,
     message:
-      "TopicSpace（リポジトリ）を作成し、指定した SourceDocument のグラフを統合しました。",
+      "リポジトリを作成し、指定した SourceDocument のグラフを統合しました。",
   };
 }
 
@@ -294,7 +294,7 @@ export async function mcpGetTopicSpaceGraph(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace が見つからないか、アクセス権がありません。",
+      message: "リポジトリが見つからないか、アクセス権がありません。",
     });
   }
 
@@ -364,7 +364,7 @@ export async function mcpAttachDocumentsToTopicSpace(
     nodeCount,
     relationshipCount,
     message:
-      "SourceDocument を TopicSpace に統合しました。node / edge provenance も記録されます。",
+      "SourceDocument をリポジトリに統合しました。node / edge provenance も記録されます。",
   };
 }
 
@@ -416,7 +416,7 @@ export async function mcpDetachDocumentFromTopicSpace(
     nodeCount,
     relationshipCount,
     message:
-      "SourceDocument を TopicSpace から切り離しました。当該ドキュメント由来の provenance も削除されます。",
+      "SourceDocument をリポジトリから切り離しました。当該ドキュメント由来の provenance も削除されます。",
   };
 }
 
@@ -446,7 +446,7 @@ export async function mcpGetTopicSpaceChangeHistory(
     count: histories.length,
     histories,
     message:
-      "TopicSpace の変更履歴を取得しました。isNodeMerge=true の行が UI 手動統合の履歴です。",
+      "リポジトリの変更履歴を取得しました。isNodeMerge=true の行が UI 手動統合の履歴です。",
   };
 }
 
@@ -552,7 +552,7 @@ export async function mcpGetTopicSpaceDriveSyncStatus(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace が見つからないか、アクセス権がありません。",
+      message: "リポジトリが見つからないか、アクセス権がありません。",
     });
   }
 

--- a/src/server/mcp/platform-handlers.ts
+++ b/src/server/mcp/platform-handlers.ts
@@ -19,6 +19,8 @@ import {
   listTopicSpaceChangeHistory,
   replayNodeMergesFromHistory,
 } from "@/server/services/kg/replay-node-merges-from-history.service";
+import { syncTopicSpaceDriveFolder } from "@/server/services/kg/sync-topic-space-drive.service";
+import { buildDriveFolderUrl } from "@/server/lib/google-drive/urls";
 import type { McpDraftHandlerCtx } from "@/server/mcp/graph-edit-draft-handlers";
 
 export type McpPlatformHandlerCtx = McpDraftHandlerCtx;
@@ -531,5 +533,58 @@ async function readTopicSpaceGraphForExport(
         sourceDocumentIds: sourceDocumentIdsByRelationshipId.get(rel.id),
       })),
     },
+  };
+}
+
+export async function mcpGetTopicSpaceDriveSyncStatus(
+  ctx: McpPlatformHandlerCtx,
+  input: { topicSpaceId: string },
+) {
+  const topicSpace = await ctx.db.topicSpace.findFirst({
+    where: {
+      id: input.topicSpaceId,
+      isDeleted: false,
+      admins: { some: { id: ctx.userId } },
+    },
+    include: { driveSync: true },
+  });
+
+  if (!topicSpace) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "TopicSpace が見つからないか、アクセス権がありません。",
+    });
+  }
+
+  const driveSync = topicSpace.driveSync;
+  return {
+    topicSpaceId: topicSpace.id,
+    configured: Boolean(driveSync),
+    enabled: driveSync?.enabled ?? false,
+    driveFolderId: driveSync?.driveFolderId ?? null,
+    driveFolderName: driveSync?.driveFolderName ?? null,
+    driveFolderUrl: driveSync?.driveFolderId
+      ? buildDriveFolderUrl(driveSync.driveFolderId)
+      : null,
+    configuredByUserId: driveSync?.configuredByUserId ?? null,
+    recursive: driveSync?.recursive ?? true,
+    lastSyncedAt: driveSync?.lastSyncedAt?.toISOString() ?? null,
+    lastSyncStatus: driveSync?.lastSyncStatus ?? null,
+    lastSyncError: driveSync?.lastSyncError ?? null,
+  };
+}
+
+export async function mcpSyncTopicSpaceDriveFolder(
+  ctx: McpPlatformHandlerCtx,
+  input: { topicSpaceId: string },
+) {
+  const result = await syncTopicSpaceDriveFolder(
+    { db: ctx.db, session: { user: { id: ctx.userId } } },
+    { topicSpaceId: input.topicSpaceId },
+  );
+
+  return {
+    ...result,
+    message: `Drive 同期完了: 作成 ${result.created}, 更新 ${result.updated}, スキップ ${result.skipped}, 削除 ${result.detached}`,
   };
 }

--- a/src/server/repositories/topic-space-graph.repository.ts
+++ b/src/server/repositories/topic-space-graph.repository.ts
@@ -32,7 +32,7 @@ export function assertTopicSpaceAdmin(
   if (!isAdmin) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace not found",
+      message: "リポジトリが見つかりません",
     });
   }
 }
@@ -46,7 +46,7 @@ export async function findTopicSpaceWithGraphAndAssertAdmin(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace not found",
+      message: "リポジトリが見つかりません",
     });
   }
   assertTopicSpaceAdmin(topicSpace, userId);

--- a/src/server/services/graph-edit-proposal/create-graph-edit-proposal.service.ts
+++ b/src/server/services/graph-edit-proposal/create-graph-edit-proposal.service.ts
@@ -47,7 +47,7 @@ export async function createGraphEditProposal(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpaceが見つかりません",
+      message: "リポジトリが見つかりません",
     });
   }
 

--- a/src/server/services/graph-edit-proposal/draft-proposal.service.ts
+++ b/src/server/services/graph-edit-proposal/draft-proposal.service.ts
@@ -22,7 +22,7 @@ export async function createDraftProposal(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpaceが見つかりません",
+      message: "リポジトリが見つかりません",
     });
   }
 

--- a/src/server/services/graph-edit-proposal/rollback-change.service.ts
+++ b/src/server/services/graph-edit-proposal/rollback-change.service.ts
@@ -42,7 +42,7 @@ export async function rollbackGraphChange(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpaceが見つかりません",
+      message: "リポジトリが見つかりません",
     });
   }
 

--- a/src/server/services/graph-edit-proposal/update-graph-edit-proposal.service.ts
+++ b/src/server/services/graph-edit-proposal/update-graph-edit-proposal.service.ts
@@ -106,7 +106,7 @@ export async function updateGraphEditProposal(
     if (!topicSpace) {
       throw new TRPCError({
         code: "NOT_FOUND",
-        message: "TopicSpaceが見つかりません",
+        message: "リポジトリが見つかりません",
       });
     }
 

--- a/src/server/services/kg/attach-documents.service.ts
+++ b/src/server/services/kg/attach-documents.service.ts
@@ -24,7 +24,7 @@ export async function attachDocumentsToTopicSpace(
   if (
     !topicSpace?.admins.some((admin) => admin.id === ctx.session.user.id)
   ) {
-    throw new Error("TopicSpace not found");
+    throw new Error("リポジトリが見つかりません");
   }
 
   const attachDocuments = await ctx.db.sourceDocument.findMany({

--- a/src/server/services/kg/create-source-document-with-graph.service.ts
+++ b/src/server/services/kg/create-source-document-with-graph.service.ts
@@ -15,6 +15,9 @@ export type CreateSourceDocumentWithGraphInput = {
   documentType?: DocumentType;
   sourceImageUrl?: string | null;
   ocrMetadata?: Prisma.InputJsonValue;
+  externalSourceId?: string | null;
+  externalModifiedAt?: Date | null;
+  contentHash?: string | null;
 };
 
 type CreateWithGraphCtx = {
@@ -90,6 +93,9 @@ export async function createSourceDocumentWithGraph(
         documentType,
         sourceImageUrl: input.sourceImageUrl ?? null,
         ocrMetadata: input.ocrMetadata ?? undefined,
+        externalSourceId: input.externalSourceId ?? null,
+        externalModifiedAt: input.externalModifiedAt ?? null,
+        contentHash: input.contentHash ?? null,
         user: { connect: { id: ctx.session.user.id } },
       },
     });

--- a/src/server/services/kg/create-topic-space-from-documents.service.ts
+++ b/src/server/services/kg/create-topic-space-from-documents.service.ts
@@ -85,7 +85,7 @@ export async function createTopicSpaceFromSourceDocuments(
   if (!linked) {
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
-      message: "TopicSpace の作成後に読み込みに失敗しました。",
+      message: "リポジトリの作成後に読み込みに失敗しました。",
     });
   }
 

--- a/src/server/services/kg/detach-documents.service.ts
+++ b/src/server/services/kg/detach-documents.service.ts
@@ -27,7 +27,7 @@ export async function detachDocumentsFromTopicSpace(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace not found",
+      message: "リポジトリが見つかりません",
     });
   }
   assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);

--- a/src/server/services/kg/replace-document-graph-from-extraction.service.ts
+++ b/src/server/services/kg/replace-document-graph-from-extraction.service.ts
@@ -1,0 +1,60 @@
+import type {
+  NodeTypeForFrontend,
+  RelationshipTypeForFrontend,
+} from "@/app/const/types";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { z } from "zod";
+import { KnowledgeGraphInputSchema } from "@/server/api/schemas/knowledge-graph";
+
+type GraphDataJson = z.infer<typeof KnowledgeGraphInputSchema>;
+
+export async function replaceDocumentGraphFromExtraction(
+  db: PrismaClient,
+  input: {
+    documentGraphId: string;
+    dataJson: GraphDataJson;
+  },
+) {
+  const nodes = input.dataJson.nodes as NodeTypeForFrontend[];
+  const relationships = input.dataJson
+    .relationships as RelationshipTypeForFrontend[];
+
+  return db.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.graphRelationship.deleteMany({
+      where: { documentGraphId: input.documentGraphId },
+    });
+    await tx.graphNode.deleteMany({
+      where: { documentGraphId: input.documentGraphId },
+    });
+
+    if (nodes.length > 0) {
+      await tx.graphNode.createMany({
+        data: nodes.map((node) => ({
+          id: node.id,
+          name: node.name,
+          label: node.label,
+          properties: node.properties ?? {},
+          documentGraphId: input.documentGraphId,
+        })),
+      });
+    }
+
+    if (relationships.length > 0) {
+      await tx.graphRelationship.createMany({
+        data: relationships.map((relationship) => ({
+          id: relationship.id,
+          fromNodeId: relationship.sourceId,
+          toNodeId: relationship.targetId,
+          type: relationship.type,
+          properties: relationship.properties ?? {},
+          documentGraphId: input.documentGraphId,
+        })),
+      });
+    }
+
+    await tx.documentGraph.update({
+      where: { id: input.documentGraphId },
+      data: { dataJson: input.dataJson as Prisma.InputJsonValue },
+    });
+  });
+}

--- a/src/server/services/kg/replace-document-graph-from-extraction.service.ts
+++ b/src/server/services/kg/replace-document-graph-from-extraction.service.ts
@@ -19,6 +19,12 @@ export async function replaceDocumentGraphFromExtraction(
   const relationships = input.dataJson
     .relationships as RelationshipTypeForFrontend[];
 
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const validRelationships = relationships.filter(
+    (relationship) =>
+      nodeIds.has(relationship.sourceId) && nodeIds.has(relationship.targetId),
+  );
+
   return db.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.graphRelationship.deleteMany({
       where: { documentGraphId: input.documentGraphId },
@@ -39,9 +45,9 @@ export async function replaceDocumentGraphFromExtraction(
       });
     }
 
-    if (relationships.length > 0) {
+    if (validRelationships.length > 0) {
       await tx.graphRelationship.createMany({
-        data: relationships.map((relationship) => ({
+        data: validRelationships.map((relationship) => ({
           id: relationship.id,
           fromNodeId: relationship.sourceId,
           toNodeId: relationship.targetId,

--- a/src/server/services/kg/sync-topic-space-drive.service.ts
+++ b/src/server/services/kg/sync-topic-space-drive.service.ts
@@ -1,0 +1,351 @@
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { KnowledgeGraphInputSchema } from "@/server/api/schemas/knowledge-graph";
+import { runExtractKGFromPlainText } from "@/server/api/routers/kg-extraction";
+import { buildDriveWebViewUrl } from "@/server/lib/google-drive/urls";
+import {
+  computeDriveContentHash,
+  fetchDriveFileText,
+  listDriveFilesInFolder,
+  resolveDocumentTypeFromDriveMime,
+  type DriveFileMeta,
+} from "@/server/lib/google-drive/fetch-document-text";
+import { buildDriveSourceMetadata } from "@/server/lib/google-drive/source-metadata";
+import {
+  getDriveClientForTopicSpaceSync,
+  isDriveSyncAvailable,
+} from "@/server/lib/google-drive/sync-client";
+import { assertTopicSpaceAdmin } from "@/server/repositories/topic-space-graph.repository";
+import { attachDocumentsToTopicSpace } from "@/server/services/kg/attach-documents.service";
+import { createSourceDocumentWithGraph } from "@/server/services/kg/create-source-document-with-graph.service";
+import { detachDocumentsFromTopicSpace } from "@/server/services/kg/detach-documents.service";
+import { replaceDocumentGraphFromExtraction } from "@/server/services/kg/replace-document-graph-from-extraction.service";
+
+type SyncCtx = {
+  db: PrismaClient;
+  session: { user: { id: string } };
+};
+
+export type DriveSyncResult = {
+  topicSpaceId: string;
+  created: number;
+  updated: number;
+  skipped: number;
+  detached: number;
+  errors: { fileName: string; message: string }[];
+};
+
+async function upsertDriveSourceDocument(
+  ctx: SyncCtx,
+  input: {
+    topicSpaceId: string;
+    file: DriveFileMeta;
+    plainText: string;
+    contentHash: string;
+    isAttached: boolean;
+    existingDocumentId?: string;
+  },
+): Promise<"created" | "updated" | "skipped"> {
+  const documentType = resolveDocumentTypeFromDriveMime(input.file.mimeType);
+  const webViewUrl =
+    input.file.webViewLink ?? buildDriveWebViewUrl(input.file.id);
+  const externalModifiedAt = new Date(input.file.modifiedTime);
+  const driveMetadata = buildDriveSourceMetadata({
+    fileId: input.file.id,
+    mimeType: input.file.mimeType,
+  });
+
+  const extracted = await runExtractKGFromPlainText(input.plainText);
+  if (!extracted) {
+    throw new Error("知識グラフの抽出に失敗しました");
+  }
+  const dataJson = KnowledgeGraphInputSchema.parse(extracted);
+
+  if (!input.existingDocumentId) {
+    const { sourceDocument } = await createSourceDocumentWithGraph(ctx, {
+      name: input.file.name,
+      url: webViewUrl,
+      dataJson,
+      documentType,
+      ocrMetadata: driveMetadata,
+      externalSourceId: input.file.id,
+      externalModifiedAt,
+      contentHash: input.contentHash,
+    });
+
+    await attachDocumentsToTopicSpace(ctx, {
+      id: input.topicSpaceId,
+      documentIds: [sourceDocument.id],
+    });
+
+    return "created";
+  }
+
+  const existing = await ctx.db.sourceDocument.findFirst({
+    where: { id: input.existingDocumentId, isDeleted: false },
+    include: { graph: true },
+  });
+
+  if (!existing?.graph) {
+    throw new Error("既存 SourceDocument の DocumentGraph が見つかりません");
+  }
+
+  if (existing.contentHash === input.contentHash) {
+    return "skipped";
+  }
+
+  if (input.isAttached) {
+    await detachDocumentsFromTopicSpace(ctx, {
+      id: input.topicSpaceId,
+      documentId: existing.id,
+    });
+  }
+
+  await replaceDocumentGraphFromExtraction(ctx.db, {
+    documentGraphId: existing.graph.id,
+    dataJson,
+  });
+
+  await ctx.db.sourceDocument.update({
+    where: { id: existing.id },
+    data: {
+      name: input.file.name,
+      url: webViewUrl,
+      documentType,
+      ocrMetadata: driveMetadata,
+      externalSourceId: input.file.id,
+      externalModifiedAt,
+      contentHash: input.contentHash,
+    },
+  });
+
+  await attachDocumentsToTopicSpace(ctx, {
+    id: input.topicSpaceId,
+    documentIds: [existing.id],
+  });
+
+  return "updated";
+}
+
+export async function syncTopicSpaceDriveFolder(
+  ctx: SyncCtx,
+  input: { topicSpaceId: string },
+): Promise<DriveSyncResult> {
+  const topicSpace = await ctx.db.topicSpace.findFirst({
+    where: { id: input.topicSpaceId, isDeleted: false },
+    include: {
+      admins: true,
+      driveSync: true,
+      sourceDocuments: {
+        where: { isDeleted: false },
+      },
+    },
+  });
+
+  if (!topicSpace) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "TopicSpace が見つかりません。",
+    });
+  }
+
+  assertTopicSpaceAdmin(topicSpace, ctx.session.user.id);
+
+  const driveSync = topicSpace.driveSync;
+  if (!driveSync?.enabled) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Drive 同期が有効化されていません。フォルダを選択してください。",
+    });
+  }
+
+  const driveAvailable = await isDriveSyncAvailable(ctx.db, driveSync);
+  if (!driveAvailable) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Google Drive が未連携です。Drive を連携してから同期してください。",
+    });
+  }
+
+  const driveClient = await getDriveClientForTopicSpaceSync(ctx.db, driveSync);
+
+  await ctx.db.topicSpaceDriveSync.update({
+    where: { id: driveSync.id },
+    data: {
+      lastSyncStatus: "running",
+      lastSyncError: null,
+    },
+  });
+
+  const result: DriveSyncResult = {
+    topicSpaceId: input.topicSpaceId,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    detached: 0,
+    errors: [],
+  };
+
+  try {
+    const driveFiles = await listDriveFilesInFolder(
+      {
+        folderId: driveSync.driveFolderId,
+        recursive: driveSync.recursive,
+      },
+      driveClient,
+    );
+
+    const driveFileIdSet = new Set(driveFiles.map((file) => file.id));
+    const existingByDriveId = new Map(
+      topicSpace.sourceDocuments
+        .filter((doc) => doc.externalSourceId)
+        .map((doc) => [doc.externalSourceId, doc]),
+    );
+    const attachedDocumentIds = new Set(
+      topicSpace.sourceDocuments.map((doc) => doc.id),
+    );
+
+    for (const file of driveFiles) {
+      try {
+        const plainText = await fetchDriveFileText(file, driveClient);
+        if (!plainText.trim()) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const contentHash = computeDriveContentHash(file, plainText);
+        const existing = existingByDriveId.get(file.id);
+        const outcome = await upsertDriveSourceDocument(ctx, {
+          topicSpaceId: input.topicSpaceId,
+          file,
+          plainText,
+          contentHash,
+          isAttached: existing ? attachedDocumentIds.has(existing.id) : false,
+          existingDocumentId: existing?.id,
+        });
+
+        if (outcome === "created") result.created += 1;
+        else if (outcome === "updated") result.updated += 1;
+        else result.skipped += 1;
+      } catch (error) {
+        result.errors.push({
+          fileName: file.name,
+          message:
+            error instanceof Error
+              ? error.message
+              : "不明なエラーが発生しました",
+        });
+      }
+    }
+
+    for (const doc of topicSpace.sourceDocuments) {
+      if (doc.externalSourceId && !driveFileIdSet.has(doc.externalSourceId)) {
+        try {
+          await detachDocumentsFromTopicSpace(ctx, {
+            id: input.topicSpaceId,
+            documentId: doc.id,
+          });
+          await ctx.db.sourceDocument.update({
+            where: { id: doc.id },
+            data: { isDeleted: true },
+          });
+          result.detached += 1;
+        } catch (error) {
+          result.errors.push({
+            fileName: doc.name,
+            message:
+              error instanceof Error
+                ? error.message
+                : "Drive から削除されたファイルの切り離しに失敗しました",
+          });
+        }
+      }
+    }
+
+    await ctx.db.topicSpaceDriveSync.update({
+      where: { id: driveSync.id },
+      data: {
+        lastSyncedAt: new Date(),
+        lastSyncStatus: result.errors.length > 0 ? "error" : "idle",
+        lastSyncError:
+          result.errors.length > 0
+            ? result.errors.map((e) => `${e.fileName}: ${e.message}`).join("; ")
+            : null,
+      },
+    });
+
+    return result;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Drive 同期に失敗しました";
+    await ctx.db.topicSpaceDriveSync.update({
+      where: { id: driveSync.id },
+      data: {
+        lastSyncStatus: "error",
+        lastSyncError: message,
+      },
+    });
+    throw error;
+  }
+}
+
+export async function syncAllEnabledTopicSpaceDriveFolders(
+  db: PrismaClient,
+): Promise<DriveSyncResult[]> {
+  const configs = await db.topicSpaceDriveSync.findMany({
+    where: { enabled: true },
+    include: {
+      topicSpace: {
+        include: { admins: true },
+      },
+    },
+  });
+
+  const results: DriveSyncResult[] = [];
+  for (const config of configs) {
+    const userId = config.configuredByUserId;
+    if (!userId) {
+      results.push({
+        topicSpaceId: config.topicSpaceId,
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        detached: 0,
+        errors: [
+          {
+            fileName: config.topicSpace.name,
+            message:
+              "configuredByUserId が未設定です。Drive 連携後にフォルダを選び直してください。",
+          },
+        ],
+      });
+      continue;
+    }
+
+    try {
+      const result = await syncTopicSpaceDriveFolder(
+        { db, session: { user: { id: userId } } },
+        { topicSpaceId: config.topicSpaceId },
+      );
+      results.push(result);
+    } catch (error) {
+      results.push({
+        topicSpaceId: config.topicSpaceId,
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        detached: 0,
+        errors: [
+          {
+            fileName: config.topicSpace.name,
+            message:
+              error instanceof Error ? error.message : "同期に失敗しました",
+          },
+        ],
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/server/services/kg/sync-topic-space-drive.service.ts
+++ b/src/server/services/kg/sync-topic-space-drive.service.ts
@@ -55,13 +55,31 @@ async function upsertDriveSourceDocument(
     mimeType: input.file.mimeType,
   });
 
+  const existing = input.existingDocumentId
+    ? await ctx.db.sourceDocument.findFirst({
+        where: { id: input.existingDocumentId, isDeleted: false },
+        include: { graph: true },
+      })
+    : null;
+
+  if (existing?.contentHash === input.contentHash) {
+    if (!input.isAttached) {
+      await attachDocumentsToTopicSpace(ctx, {
+        id: input.topicSpaceId,
+        documentIds: [existing.id],
+      });
+      return "updated";
+    }
+    return "skipped";
+  }
+
   const extracted = await runExtractKGFromPlainText(input.plainText);
   if (!extracted) {
     throw new Error("知識グラフの抽出に失敗しました");
   }
   const dataJson = KnowledgeGraphInputSchema.parse(extracted);
 
-  if (!input.existingDocumentId) {
+  if (!existing) {
     const { sourceDocument } = await createSourceDocumentWithGraph(ctx, {
       name: input.file.name,
       url: webViewUrl,
@@ -81,17 +99,8 @@ async function upsertDriveSourceDocument(
     return "created";
   }
 
-  const existing = await ctx.db.sourceDocument.findFirst({
-    where: { id: input.existingDocumentId, isDeleted: false },
-    include: { graph: true },
-  });
-
-  if (!existing?.graph) {
+  if (!existing.graph) {
     throw new Error("既存 SourceDocument の DocumentGraph が見つかりません");
-  }
-
-  if (existing.contentHash === input.contentHash) {
-    return "skipped";
   }
 
   if (input.isAttached) {
@@ -145,7 +154,7 @@ export async function syncTopicSpaceDriveFolder(
   if (!topicSpace) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "TopicSpace が見つかりません。",
+      message: "リポジトリが見つかりません。",
     });
   }
 

--- a/src/server/services/scan/resolve-source-document-plain-text.ts
+++ b/src/server/services/scan/resolve-source-document-plain-text.ts
@@ -1,13 +1,47 @@
 import { DocumentType } from "@prisma/client";
 import { getTextFromDocumentFile } from "@/app/_utils/text/text";
 import type { OcrMetadata } from "@/server/api/schemas/scan";
+import { db } from "@/server/db";
+import { fetchDriveFileText } from "@/server/lib/google-drive/fetch-document-text";
+import { readDriveMimeType } from "@/server/lib/google-drive/source-metadata";
+import { getGoogleDriveClientForUser } from "@/server/lib/google-drive/user-oauth";
 import { resolveScanPlainText } from "@/server/services/scan/resolve-scan-plain-text";
 
 type SourceDocumentTextSource = {
   url: string;
+  name?: string;
+  userId?: string;
   documentType: DocumentType;
   ocrMetadata: unknown;
+  externalSourceId?: string | null;
 };
+
+async function resolveDriveBackedPlainText(
+  document: SourceDocumentTextSource,
+): Promise<string> {
+  const fileId = document.externalSourceId?.trim();
+  const userId = document.userId?.trim();
+  if (!fileId || !userId) {
+    throw new Error("Drive ドキュメントの externalSourceId または userId が未設定です");
+  }
+
+  const mimeType =
+    readDriveMimeType(document.ocrMetadata) ??
+    (document.documentType === DocumentType.INPUT_PDF
+      ? "application/pdf"
+      : "text/plain");
+
+  const drive = await getGoogleDriveClientForUser(db, userId);
+  return fetchDriveFileText(
+    {
+      id: fileId,
+      name: document.name ?? fileId,
+      mimeType,
+      modifiedTime: new Date().toISOString(),
+    },
+    drive,
+  );
+}
 
 export async function resolveSourceDocumentPlainText(
   document: SourceDocumentTextSource,
@@ -28,13 +62,32 @@ export async function resolveSourceDocumentPlainText(
     }
   }
 
+  if (
+    document.externalSourceId &&
+    (document.documentType === DocumentType.INPUT_DRIVE ||
+      document.documentType === DocumentType.INPUT_PDF)
+  ) {
+    try {
+      return await resolveDriveBackedPlainText(document);
+    } catch (error) {
+      console.error("Failed to load drive-backed document text", {
+        documentType: document.documentType,
+        error,
+      });
+      return "";
+    }
+  }
+
   const url = document.url?.trim();
   if (!url) {
     return "";
   }
 
   try {
-    return await getTextFromDocumentFile(url, document.documentType);
+    return await getTextFromDocumentFile(url, document.documentType, {
+      fileName: document.name,
+      ocrMetadata: document.ocrMetadata,
+    });
   } catch (error) {
     console.error("Failed to load source document text", {
       documentType: document.documentType,

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
     {
       "path": "/api/cron/trans-e-embedding",
       "schedule": "*/1 * * * *"
+    },
+    {
+      "path": "/api/cron/topic-space-drive-sync",
+      "schedule": "0 */6 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- TopicSpace 単位で Google Drive フォルダを同期し、`INPUT_DRIVE` として KG 化する機能を追加（ユーザー OAuth + Google Picker のみ、サービスアカウント方式は廃止）
- Drive 連携 UI（連携・フォルダ選択・手動同期）、6 時間ごとの Cron、MCP ツール（`sync_topic_space_drive_folder` / `get_topic_space_drive_sync_status`）、`npm run export:topic-space` CLI を追加
- Prisma マイグレーション（`TopicSpaceDriveSync`, `UserGoogleDriveConnection`, `SourceDocument.externalSourceId` 等）とセットアップ手順 `docs/topic-space-drive-sync.md` を追加

**Note:** このブランチには、Drive 同期の基盤となる TopicSpace provenance / Platform MCP の先行コミット（2件）も含まれます。

## Test plan

- [ ] `npm run db:migrate` でマイグレーション適用
- [ ] Google Cloud で Drive API / Picker API 有効化、OAuth リダイレクト URI（`/api/google-drive/callback`）と Picker 用 API キーを設定
- [ ] `.env` に `GOOGLE_CLIENT_ID/SECRET`, `NEXTAUTH_SECRET`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_GOOGLE_PICKER_API_KEY`, `NEXT_PUBLIC_GOOGLE_APP_ID` を設定
- [ ] TopicSpace 画面で Drive 連携 → Picker でフォルダ選択 → 「今すぐ同期」
- [ ] `npm run build` が成功すること
- [ ] （任意）MCP `sync_topic_space_drive_folder` / `export:topic-space` CLI の動作確認


Made with [Cursor](https://cursor.com)