### PR TITLE
perf: KG Phase2 with gpt-4o-mini and chunk-local context

### DIFF
--- a/src/app/_components/form/document-form.tsx
+++ b/src/app/_components/form/document-form.tsx
@@ -111,15 +111,7 @@ export const DocumentForm = ({
       });
       const uniqueNodes = Array.from(uniqueNodesMap.values());
 
-      // Build Context
-      const contextString = uniqueNodes
-        .map((n) => {
-          const ja = n.properties?.name_ja ? `(${n.properties.name_ja})` : "";
-          return `- ${n.name} [${n.label}] ${ja}`;
-        })
-        .join("\n");
-
-      // 3. Phase 2 Loop
+      // 3. Phase 2 Loop (chunk-local context on server)
       for (let i = 0; i < documents.length; i += BATCH_SIZE) {
         const batch = documents.slice(i, i + BATCH_SIZE);
         setProgress(
@@ -131,7 +123,7 @@ export const DocumentForm = ({
 
         const res = await extractPhase2.mutateAsync({
           documents: batch,
-          contextualInfo: contextString,
+          phase1Nodes: uniqueNodes,
           customMappingRules,
         });
 

--- a/src/server/api/routers/kg-extraction.ts
+++ b/src/server/api/routers/kg-extraction.ts
@@ -118,7 +118,7 @@ export const extractionProcedures = {
     .mutation(async ({ input }) => {
       const {
         documents,
-        contextualInfo,
+        phase1Nodes,
         schema,
         additionalPrompt,
         customMappingRules,
@@ -128,7 +128,7 @@ export const extractionProcedures = {
         const extractor = new IterativeGraphExtractor();
         const nodesAndRelationships = await extractor.extractPhase2(
           documents,
-          contextualInfo,
+          phase1Nodes,
           {
             localFilePath: "",
             isPlaneTextMode: false,

--- a/src/server/api/schemas/knowledge-graph.ts
+++ b/src/server/api/schemas/knowledge-graph.ts
@@ -328,15 +328,15 @@ export const ExtractPhase1InputSchema = z.object({
   customMappingRules: ExtractInputSchema.shape.customMappingRules,
 });
 
-export const ExtractPhase2InputSchema = ExtractPhase1InputSchema.extend({
-  contextualInfo: z.string(),
-});
-
 export const NodeInputSchema = z.object({
   id: z.string(),
   name: z.string(),
   label: z.string(),
   properties: z.record(z.string()),
+});
+
+export const ExtractPhase2InputSchema = ExtractPhase1InputSchema.extend({
+  phase1Nodes: z.array(NodeInputSchema),
 });
 
 export const RelationshipInputSchema = z.object({

--- a/src/server/lib/extractors/build-local-context.test.ts
+++ b/src/server/lib/extractors/build-local-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLocalContextFromNodes,
+  filterNodesForChunk,
+} from "./build-local-context";
+import type { NodeTypeForFrontend } from "@/app/const/types";
+
+function node(
+  name: string,
+  label: string,
+  props: Record<string, string> = {},
+): NodeTypeForFrontend {
+  return { id: name, name, label, properties: props };
+}
+
+describe("buildLocalContextFromNodes", () => {
+  const nodes = [
+    node("Joseph Beuys", "Person", { name_ja: "ヨーゼフ・ボイス", name_en: "Joseph Beuys" }),
+    node("Documentary Film", "Concept"),
+    node("Unrelated Entity", "Organization"),
+  ];
+
+  it("filters nodes that appear in chunk text by name", () => {
+    const chunk = "Joseph Beuys was a German artist.";
+    expect(filterNodesForChunk(chunk, nodes).map((n) => n.name)).toEqual([
+      "Joseph Beuys",
+    ]);
+  });
+
+  it("filters nodes that appear by Japanese name", () => {
+    const chunk = "ヨーゼフ・ボイスに関する記述";
+    expect(filterNodesForChunk(chunk, nodes).map((n) => n.name)).toEqual([
+      "Joseph Beuys",
+    ]);
+  });
+
+  it("builds context string only for matching nodes", () => {
+    const chunk = "Documentary Film is discussed here.";
+    expect(buildLocalContextFromNodes(chunk, nodes)).toBe(
+      "- Documentary Film [Concept] ",
+    );
+  });
+});

--- a/src/server/lib/extractors/build-local-context.test.ts
+++ b/src/server/lib/extractors/build-local-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildLocalContextFromNodes,
   filterNodesForChunk,
+  termAppearsInChunk,
 } from "./build-local-context";
 import type { NodeTypeForFrontend } from "@/app/const/types";
 
@@ -13,9 +14,43 @@ function node(
   return { id: name, name, label, properties: props };
 }
 
+describe("termAppearsInChunk", () => {
+  it("matches ASCII terms with word boundaries (case insensitive)", () => {
+    expect(termAppearsInChunk("Joseph Beuys", "joseph beuys was here")).toBe(
+      true,
+    );
+    expect(termAppearsInChunk("Joseph Beuys", "JOSEPH BEUYS")).toBe(true);
+  });
+
+  it("does not match ASCII terms as substrings of other words", () => {
+    expect(termAppearsInChunk("AI", "email and detail")).toBe(false);
+    expect(termAppearsInChunk("Art", "particular focus")).toBe(false);
+    expect(termAppearsInChunk("He", "the museum here")).toBe(false);
+  });
+
+  it("matches short ASCII terms when they are standalone words", () => {
+    expect(termAppearsInChunk("AI", "Advances in AI research")).toBe(true);
+  });
+
+  it("matches Japanese terms by substring", () => {
+    expect(termAppearsInChunk("ヨーゼフ・ボイス", "ヨーゼフ・ボイスに関する記述")).toBe(
+      true,
+    );
+    expect(termAppearsInChunk("アート", "日本型アートプロジェクト")).toBe(true);
+  });
+
+  it("does not false-match Japanese terms across unrelated text", () => {
+    expect(termAppearsInChunk("美術", "生物学の研究")).toBe(false);
+  });
+});
+
 describe("buildLocalContextFromNodes", () => {
   const nodes = [
-    node("Joseph Beuys", "Person", { name_ja: "ヨーゼフ・ボイス", name_en: "Joseph Beuys" }),
+    node("Joseph Beuys", "Person", {
+      name_ja: "ヨーゼフ・ボイス",
+      name_en: "Joseph Beuys",
+    }),
+    node("AI", "Concept"),
     node("Documentary Film", "Concept"),
     node("Unrelated Entity", "Organization"),
   ];
@@ -32,6 +67,11 @@ describe("buildLocalContextFromNodes", () => {
     expect(filterNodesForChunk(chunk, nodes).map((n) => n.name)).toEqual([
       "Joseph Beuys",
     ]);
+  });
+
+  it("excludes nodes that would false-match inside other English words", () => {
+    const chunk = "Please email the curator about the exhibition claim.";
+    expect(filterNodesForChunk(chunk, nodes).map((n) => n.name)).toEqual([]);
   });
 
   it("builds context string only for matching nodes", () => {

--- a/src/server/lib/extractors/build-local-context.ts
+++ b/src/server/lib/extractors/build-local-context.ts
@@ -1,0 +1,35 @@
+import type { NodeTypeForFrontend } from "@/app/const/types";
+
+function nodeAppearsInChunk(
+  node: NodeTypeForFrontend,
+  chunkText: string,
+): boolean {
+  if (chunkText.includes(node.name)) return true;
+
+  const ja = node.properties?.name_ja?.trim();
+  if (ja && chunkText.includes(ja)) return true;
+
+  const en = node.properties?.name_en?.trim();
+  if (en && en !== node.name && chunkText.includes(en)) return true;
+
+  return false;
+}
+
+export function filterNodesForChunk(
+  chunkText: string,
+  nodes: NodeTypeForFrontend[],
+): NodeTypeForFrontend[] {
+  return nodes.filter((node) => nodeAppearsInChunk(node, chunkText));
+}
+
+export function buildLocalContextFromNodes(
+  chunkText: string,
+  nodes: NodeTypeForFrontend[],
+): string {
+  return filterNodesForChunk(chunkText, nodes)
+    .map((n) => {
+      const ja = n.properties?.name_ja ? `(${n.properties.name_ja})` : "";
+      return `- ${n.name} [${n.label}] ${ja}`;
+    })
+    .join("\n");
+}

--- a/src/server/lib/extractors/build-local-context.ts
+++ b/src/server/lib/extractors/build-local-context.ts
@@ -1,16 +1,33 @@
 import type { NodeTypeForFrontend } from "@/app/const/types";
 
+/** 日本語・CJK を含む語は部分一致、ASCII ラテン語のみは単語境界 + 大文字小文字無視 */
+function containsJapaneseOrNonAscii(term: string): boolean {
+  return /[\u3040-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(term) || /[^\x00-\x7F]/.test(term);
+}
+
+export function termAppearsInChunk(term: string, chunkText: string): boolean {
+  const trimmed = term.trim();
+  if (!trimmed) return false;
+
+  if (containsJapaneseOrNonAscii(trimmed)) {
+    return chunkText.includes(trimmed);
+  }
+
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(chunkText);
+}
+
 function nodeAppearsInChunk(
   node: NodeTypeForFrontend,
   chunkText: string,
 ): boolean {
-  if (chunkText.includes(node.name)) return true;
+  if (termAppearsInChunk(node.name, chunkText)) return true;
 
   const ja = node.properties?.name_ja?.trim();
-  if (ja && chunkText.includes(ja)) return true;
+  if (ja && termAppearsInChunk(ja, chunkText)) return true;
 
   const en = node.properties?.name_en?.trim();
-  if (en && en !== node.name && chunkText.includes(en)) return true;
+  if (en && en !== node.name && termAppearsInChunk(en, chunkText)) return true;
 
   return false;
 }

--- a/src/server/lib/extractors/iterative.ts
+++ b/src/server/lib/extractors/iterative.ts
@@ -9,6 +9,7 @@ import type {
   ExtractorOptions,
   NodesAndRelationships,
 } from "./base";
+import { buildLocalContextFromNodes } from "./build-local-context";
 import { buildMappingPrompt, buildSystemPrompt } from "./base";
 import type {
   NodeTypeForFrontend,
@@ -21,13 +22,22 @@ import type {
 } from "node_modules/@langchain/community/dist/graphs/document";
 import type { Document } from "@langchain/core/documents";
 
+const PHASE1_MODEL = "gpt-4o";
+const PHASE2_MODEL = "gpt-4o-mini";
+
 export class IterativeGraphExtractor implements Extractor {
-  private llm: ChatOpenAI;
+  private phase1Llm: ChatOpenAI;
+  private phase2Llm: ChatOpenAI;
 
   constructor() {
-    this.llm = new ChatOpenAI({
+    this.phase1Llm = new ChatOpenAI({
       temperature: 0.1,
-      model: "gpt-4o", // Using a cost-effective but capable model
+      model: PHASE1_MODEL,
+      maxTokens: 16000,
+    });
+    this.phase2Llm = new ChatOpenAI({
+      temperature: 0.1,
+      model: PHASE2_MODEL,
       maxTokens: 16000,
     });
   }
@@ -88,11 +98,12 @@ export class IterativeGraphExtractor implements Extractor {
       const phase1Data = await this.extractPhase1(documents, options);
       if (!phase1Data) return null;
 
-      // Build context from Phase 1
-      const context = this.buildContextFromNodes(phase1Data.nodes);
-
-      // Phase 2 execution
-      const phase2Data = await this.extractPhase2(documents, context, options);
+      // Phase 2 execution (chunk-local context, gpt-4o-mini)
+      const phase2Data = await this.extractPhase2(
+        documents,
+        phase1Data.nodes,
+        options,
+      );
       if (!phase2Data) return phase1Data;
 
       // Merge results
@@ -203,7 +214,7 @@ export class IterativeGraphExtractor implements Extractor {
     ]);
 
     const transformer = new LLMGraphTransformer({
-      llm: this.llm,
+      llm: this.phase1Llm,
       allowedNodes: schema?.allowedNodes,
       allowedRelationships: schema?.allowedRelationships,
       prompt: customPrompt,
@@ -215,19 +226,44 @@ export class IterativeGraphExtractor implements Extractor {
 
   async extractPhase2(
     documents: Document[],
+    phase1Nodes: NodeTypeForFrontend[],
+    options: ExtractorOptions,
+  ): Promise<NodesAndRelationships> {
+    console.log("--- Starting Phase 2: Contextual Refinement ---");
+
+    let merged: NodesAndRelationships = { nodes: [], relationships: [] };
+
+    for (const document of documents) {
+      const localContext = buildLocalContextFromNodes(
+        document.pageContent,
+        phase1Nodes,
+      );
+      const chunkResult = await this.extractPhase2ForDocument(
+        document,
+        localContext,
+        options,
+      );
+      merged = this.mergeResults(merged, chunkResult);
+    }
+
+    return merged;
+  }
+
+  private async extractPhase2ForDocument(
+    document: Document,
     contextualInfo: string,
     options: ExtractorOptions,
   ): Promise<NodesAndRelationships> {
     const { schema, additionalPrompt, customMappingRules } = options;
 
-    console.log("--- Starting Phase 2: Contextual Refinement ---");
-
     const mappingPrompt = buildMappingPrompt(customMappingRules);
-    const fullContext = `IMPORTANT: The following entities have already been identified in the document set. 
+    const fullContext = contextualInfo.trim()
+      ? `IMPORTANT: The following entities have already been identified in this text segment.
 Focus on finding relationships involving these entities that might have been missed in the first pass.
 
 EXISTING ENTITIES:
-${contextualInfo}`;
+${contextualInfo}`
+      : `IMPORTANT: Focus on finding relationships between entities mentioned in this text segment that might have been missed in the first pass.`;
 
     const systemPrompt = buildSystemPrompt({
       mappingPrompt,
@@ -244,13 +280,15 @@ ${contextualInfo}`;
     ]);
 
     const transformer = new LLMGraphTransformer({
-      llm: this.llm,
+      llm: this.phase2Llm,
       allowedNodes: schema?.allowedNodes,
       allowedRelationships: schema?.allowedRelationships,
       prompt: customPrompt,
     });
 
-    const graphDocuments = await transformer.convertToGraphDocuments(documents);
+    const graphDocuments = await transformer.convertToGraphDocuments([
+      document,
+    ]);
     return this.convertToFrontendFormat(graphDocuments);
   }
 

--- a/src/server/lib/extractors/iterative.ts
+++ b/src/server/lib/extractors/iterative.ts
@@ -231,18 +231,18 @@ export class IterativeGraphExtractor implements Extractor {
   ): Promise<NodesAndRelationships> {
     console.log("--- Starting Phase 2: Contextual Refinement ---");
 
-    let merged: NodesAndRelationships = { nodes: [], relationships: [] };
+    const chunkResults = await Promise.all(
+      documents.map((document) => {
+        const localContext = buildLocalContextFromNodes(
+          document.pageContent,
+          phase1Nodes,
+        );
+        return this.extractPhase2ForDocument(document, localContext, options);
+      }),
+    );
 
-    for (const document of documents) {
-      const localContext = buildLocalContextFromNodes(
-        document.pageContent,
-        phase1Nodes,
-      );
-      const chunkResult = await this.extractPhase2ForDocument(
-        document,
-        localContext,
-        options,
-      );
+    let merged: NodesAndRelationships = { nodes: [], relationships: [] };
+    for (const chunkResult of chunkResults) {
       merged = this.mergeResults(merged, chunkResult);
     }
 

--- a/src/server/services/kg-extraction/process-kg-extraction-job.service.ts
+++ b/src/server/services/kg-extraction/process-kg-extraction-job.service.ts
@@ -12,6 +12,7 @@ import {
   type PrismaClient,
 } from "@prisma/client";
 import { finalizeAccumulatedKg } from "./finalize-accumulated-kg.service";
+import { resyncDocumentGraphToTopicSpace } from "./resync-document-graph-to-topic-space.service";
 
 const EMPTY_GRAPH = { nodes: [], relationships: [] };
 
@@ -162,7 +163,6 @@ export async function processKgExtractionJob(
       }
 
       const uniqueNodes = dedupeNodesByName(accumulatedNodes);
-      const contextSnapshot = extractor.buildContextFromNodes(uniqueNodes);
 
       await db.kgExtractionJob.update({
         where: { id: job.id },
@@ -170,7 +170,7 @@ export async function processKgExtractionJob(
           phase: KgExtractionPhase.PHASE2,
           totalChunks,
           processedChunks: 0,
-          contextSnapshot,
+          contextSnapshot: null,
           accumulatedNodes: uniqueNodes,
           accumulatedRelationships,
           status: JobStatus.PENDING,
@@ -189,18 +189,15 @@ export async function processKgExtractionJob(
     }
 
     if (job.phase === KgExtractionPhase.PHASE2) {
-      if (!job.contextSnapshot) {
-        throw new Error("Phase2 の contextSnapshot が未設定です");
+      const phase1Nodes = parseAccumulatedNodes(job.accumulatedNodes);
+      if (phase1Nodes.length === 0) {
+        throw new Error("Phase2 の accumulatedNodes が未設定です");
       }
 
       const start = job.processedChunks;
       const end = Math.min(start + job.batchSize, totalChunks);
       const batch = documents.slice(start, end);
-      const result = await extractor.extractPhase2(
-        batch,
-        job.contextSnapshot,
-        options,
-      );
+      const result = await extractor.extractPhase2(batch, phase1Nodes, options);
 
       accumulatedNodes = [...accumulatedNodes, ...result.nodes];
       accumulatedRelationships = [
@@ -238,6 +235,14 @@ export async function processKgExtractionJob(
         sourceDocumentId: job.sourceDocumentId,
         dataJson,
       });
+
+      if (job.topicSpaceId) {
+        await resyncDocumentGraphToTopicSpace(db, {
+          userId: job.userId,
+          topicSpaceId: job.topicSpaceId,
+          sourceDocumentId: job.sourceDocumentId,
+        });
+      }
 
       await db.kgExtractionJob.update({
         where: { id: job.id },

--- a/src/server/services/kg-extraction/resync-document-graph-to-topic-space.service.ts
+++ b/src/server/services/kg-extraction/resync-document-graph-to-topic-space.service.ts
@@ -1,0 +1,40 @@
+import type { PrismaClient } from "@prisma/client";
+import { attachDocumentsToTopicSpace } from "@/server/services/kg/attach-documents.service";
+import { detachDocumentsFromTopicSpace } from "@/server/services/kg/detach-documents.service";
+
+/**
+ * 非同期 KG 完了後、ドキュメントグラフをリポジトリに反映する。
+ * 空グラフのままアタッチ済みの場合は detach → attach でマージし直す。
+ */
+export async function resyncDocumentGraphToTopicSpace(
+  db: PrismaClient,
+  input: {
+    userId: string;
+    topicSpaceId: string;
+    sourceDocumentId: string;
+  },
+) {
+  const topicSpace = await db.topicSpace.findFirst({
+    where: { id: input.topicSpaceId, isDeleted: false },
+    include: {
+      sourceDocuments: { where: { id: input.sourceDocumentId, isDeleted: false } },
+    },
+  });
+
+  if (!topicSpace) return;
+
+  const ctx = { db, session: { user: { id: input.userId } } };
+  const isAttached = topicSpace.sourceDocuments.length > 0;
+
+  if (isAttached) {
+    await detachDocumentsFromTopicSpace(ctx, {
+      id: input.topicSpaceId,
+      documentId: input.sourceDocumentId,
+    });
+  }
+
+  await attachDocumentsToTopicSpace(ctx, {
+    id: input.topicSpaceId,
+    documentIds: [input.sourceDocumentId],
+  });
+}

--- a/src/server/services/kg-extraction/resync-document-graph-to-topic-space.service.ts
+++ b/src/server/services/kg-extraction/resync-document-graph-to-topic-space.service.ts
@@ -31,10 +31,9 @@ export async function resyncDocumentGraphToTopicSpace(
       id: input.topicSpaceId,
       documentId: input.sourceDocumentId,
     });
+    await attachDocumentsToTopicSpace(ctx, {
+      id: input.topicSpaceId,
+      documentIds: [input.sourceDocumentId],
+    });
   }
-
-  await attachDocumentsToTopicSpace(ctx, {
-    id: input.topicSpaceId,
-    documentIds: [input.sourceDocumentId],
-  });
 }


### PR DESCRIPTION
## Summary

- Phase2 の LLM を **gpt-4o-mini** に切り替え（Phase1 は gpt-4o のまま）
- Phase2 の context を **チャンク内に登場する Phase1 エンティティのみ**に限定し、大規模文書でのトークン消費を削減
- バッチ KG ジョブ完了後に TopicSpace へグラフを再マージする `resyncDocumentGraphToTopicSpace` を追加（前回ローカル検証で判明した空グラフ問題の修正）

## 変更詳細

| 項目 | 内容 |
|------|------|
| `IterativeGraphExtractor` | Phase1/Phase2 で別 LLM。Phase2 はチャンクごとに local context を構築 |
| `build-local-context.ts` | チャンクテキストに name / name_ja / name_en が含まれるノードをフィルタ |
| `KgExtractionJob` | Phase2 は `accumulatedNodes` から local context を生成（全文 `contextSnapshot` 依存を廃止） |
| `extractPhase2` tRPC | 入力を `contextualInfo` → `phase1Nodes` に変更 |
| `document-form` | Phase2 呼び出しを新 API に合わせて更新 |

## Test plan

- [ ] `npx vitest run src/server/lib/extractors/build-local-context.test.ts`
- [ ] `npm run build`
- [ ] 小〜中規模文書で Phase1 + Phase2 が従来どおり動作すること
- [ ] 200ページ級文書で Phase2 の 1 completion トークン数が大幅に減ること（OpenAI ログで確認）
- [ ] バッチ KG 完了後、TopicSpace グラフにノードが反映されること


Made with [Cursor](https://cursor.com)