### PR TITLE
Fix SourceDocument graph icon linking to /graph/undefined

### DIFF
--- a/src/app/_components/list/document-list.tsx
+++ b/src/app/_components/list/document-list.tsx
@@ -88,7 +88,10 @@ export const DocumentList = ({
                 <Button
                   className="z-10 !h-8 !w-8 bg-transparent !p-2 text-sm hover:bg-slate-50/10"
                   onClick={() => {
-                    router.push(`/graph/${document.graph?.id}`);
+                    const graphId = document.graph?.id;
+                    if (graphId) {
+                      router.push(`/graph/${graphId}`);
+                    }
                   }}
                 >
                   <GraphIcon height={16} width={16} color="white" />

--- a/src/app/_components/list/topic-graph-document-list.tsx
+++ b/src/app/_components/list/topic-graph-document-list.tsx
@@ -66,7 +66,10 @@ export const TopicGraphDocumentList = ({
               <Button
                 className="z-10 !h-8 !w-8 bg-transparent !p-2 text-sm hover:bg-slate-50/10"
                 onClick={() => {
-                  router.push(`/graph/${document.graph?.id}`);
+                  const graphId = document.graph?.id;
+                  if (graphId) {
+                    router.push(`/graph/${graphId}`);
+                  }
                 }}
               >
                 <GraphIcon height={16} width={16} color="white" />

--- a/src/app/_utils/kg/frontend-properties.ts
+++ b/src/app/_utils/kg/frontend-properties.ts
@@ -88,13 +88,27 @@ export const formTopicSpaceForFrontendPrivate = ({
         nodes: topicSpace.nodes,
         relationships: topicSpace.relationships,
       }),
-      sourceDocuments: topicSpace.sourceDocuments?.map((doc) => ({
-        ...doc,
-        graph:
-          doc.graph && doc.graph.graphNodes && doc.graph.graphRelationships
-            ? formDocumentGraphForFrontend(doc.graph, preferredLocale)
-            : null,
-      })),
+      sourceDocuments: topicSpace.sourceDocuments?.map((doc) => {
+        if (!doc.graph) {
+          return { ...doc, graph: null };
+        }
+        if (doc.graph.graphNodes && doc.graph.graphRelationships) {
+          return {
+            ...doc,
+            graph: formDocumentGraphForFrontend(doc.graph, preferredLocale),
+          };
+        }
+        return {
+          ...doc,
+          graph: {
+            id: doc.graph.id,
+            dataJson: (doc.graph.dataJson ?? {
+              nodes: [],
+              relationships: [],
+            }) as GraphDocumentForFrontend,
+          },
+        };
+      }),
       tags: topicSpace.tags,
       admins: topicSpace.admins,
     };
@@ -141,13 +155,27 @@ export const formTopicSpaceForFrontendPublic = (
         nodes: topicSpace.nodes,
         relationships: topicSpace.relationships,
       }),
-      sourceDocuments: topicSpace.sourceDocuments?.map((doc) => ({
-        ...doc,
-        graph:
-          doc.graph && doc.graph.graphNodes && doc.graph.graphRelationships
-            ? formDocumentGraphForFrontend(doc.graph, preferredLocale)
-            : null,
-      })),
+      sourceDocuments: topicSpace.sourceDocuments?.map((doc) => {
+        if (!doc.graph) {
+          return { ...doc, graph: null };
+        }
+        if (doc.graph.graphNodes && doc.graph.graphRelationships) {
+          return {
+            ...doc,
+            graph: formDocumentGraphForFrontend(doc.graph, preferredLocale),
+          };
+        }
+        return {
+          ...doc,
+          graph: {
+            id: doc.graph.id,
+            dataJson: (doc.graph.dataJson ?? {
+              nodes: [],
+              relationships: [],
+            }) as GraphDocumentForFrontend,
+          },
+        };
+      }),
       tags: topicSpace.tags,
       admins: topicSpace.admins,
     };

--- a/src/app/_utils/kg/frontend-properties.ts
+++ b/src/app/_utils/kg/frontend-properties.ts
@@ -101,7 +101,7 @@ export const formTopicSpaceForFrontendPrivate = ({
         return {
           ...doc,
           graph: {
-            id: doc.graph.id,
+            ...doc.graph,
             dataJson: (doc.graph.dataJson ?? {
               nodes: [],
               relationships: [],
@@ -168,7 +168,7 @@ export const formTopicSpaceForFrontendPublic = (
         return {
           ...doc,
           graph: {
-            id: doc.graph.id,
+            ...doc.graph,
             dataJson: (doc.graph.dataJson ?? {
               nodes: [],
               relationships: [],


### PR DESCRIPTION
## Summary
- Preserve `document.graph.id` in topic space API responses even when graph nodes/relationships are not eagerly loaded (`withDocumentGraph: false`).
- Add navigation guards in document list components so graph icon clicks do not route to `/graph/undefined`.

## Root cause
`formTopicSpaceForFrontendPrivate/Public` returned `graph: null` when only the DocumentGraph record was loaded without nested nodes, so the graph icon had no id to link to.

## Test plan
- [ ] Open `/topic-spaces/[id]` and click the graph icon on a source document with an existing graph
- [ ] Confirm navigation goes to `/graph/[documentGraphId]` (not `/graph/undefined`)
- [ ] Confirm topic graph detail/editor views still load per-document graph data when selecting a document


Made with [Cursor](https://cursor.com)