### PR TITLE
Fix KG iterative extraction: reasoning_effort, finalize robustness, prompt V2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@
 # DISCORD_CLIENT_ID=""
 # DISCORD_CLIENT_SECRET=""
 OPENAI_API_KEY=""
+# 知識グラフ抽出に使うモデル(任意・未設定なら下記デフォルト)。
+# Phase1=初期抽出 / Phase2=関係補完。既定はコスト最適な GPT-5.4 mini/nano。
+# KG_PHASE1_MODEL="gpt-5.4-mini"
+# KG_PHASE2_MODEL="gpt-5.4-nano"
+# reasoning 系モデルの推論強度: none | low | medium | high | xhigh (モデル依存, 既定 low)
+# 空文字にするとモデル既定に委ねる。GPT-5.4 系は "minimal" 非対応なので注意。
+# KG_PHASE1_REASONING_EFFORT="low"
+# KG_PHASE2_REASONING_EFFORT="low"
 TMP_DIRECTORY="./public/tmp" 
 
 NEXT_PUBLIC_SUPABASE_URL=""

--- a/src/app/_components/d3/force/graph.tsx
+++ b/src/app/_components/d3/force/graph.tsx
@@ -462,6 +462,14 @@ export const D3ForceGraph = ({
     });
   }, [initLinks, initNodes]);
 
+  // シミュレーション構築 effect からは参照ではなく ref 経由で最新値を読む。
+  // （graphDocument の参照ブレで newLinks/initNodes の参照が毎レンダー変わっても
+  //   effect を再実行させず、無限ループを防ぐ。実データの変化は simulationDataKey で検知する）
+  const initNodesRef = useRef(initNodes);
+  initNodesRef.current = initNodes;
+  const newLinksRef = useRef(newLinks);
+  newLinksRef.current = newLinks;
+
   /** 分類対象はフォーカス中のエッジ1本のみ（LLM負荷抑制） */
   const linksForEdgeSemanticAnimation = useMemo(() => {
     if (!focusedLink?.id || !focusedLink.type) return [];
@@ -758,6 +766,8 @@ export const D3ForceGraph = ({
   }, [currentScale, isGraphFullScreen, isLargeGraph]);
 
   useEffect(() => {
+    const initNodes = initNodesRef.current;
+    const newLinks = newLinksRef.current;
     // width/heightが無効な値の場合はシミュレーションを初期化しない
     if (width <= 0 || height <= 0 || !initNodes.length || !newLinks.length) {
       return;
@@ -955,8 +965,6 @@ export const D3ForceGraph = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     simulationDataKey,
-    newLinks,
-    initNodes,
     hasValidDimensions,
     isGraphFullScreen,
     isLargeGraph,

--- a/src/app/_components/document/document-detail.tsx
+++ b/src/app/_components/document/document-detail.tsx
@@ -11,7 +11,10 @@ import { api } from "@/trpc/react";
 import { exportTxt } from "@/app/_utils/sys/svg";
 import { useRef, useState } from "react";
 import type { CustomNodeType, CustomLinkType } from "@/app/const/types";
+import { useTranslations } from "next-intl";
+import { LiveSimulationToggleButton } from "../view/graph-view/live-simulation-toggle-button";
 export const DocumentDetail = ({ documentId }: { documentId: string }) => {
+  const t = useTranslations("view");
   const router = useRouter();
   const [innerWidth, innerHeight] = useWindowSize();
   const graphAreaWidth = (innerWidth ?? 100) / 2 - 24;
@@ -26,6 +29,8 @@ export const DocumentDetail = ({ documentId }: { documentId: string }) => {
   const [focusedLink, setFocusedLink] = useState<CustomLinkType | undefined>(
     undefined,
   );
+  const [enableLiveSimulation, setEnableLiveSimulation] =
+    useState<boolean>(true);
   const svgRef = useRef<SVGSVGElement>(null);
 
   if (!document) return null;
@@ -43,6 +48,7 @@ export const DocumentDetail = ({ documentId }: { documentId: string }) => {
         setFocusedNode={setFocusedNode}
         focusedLink={focusedLink}
         setFocusedLink={setFocusedLink}
+        enableLiveSimulation={enableLiveSimulation}
         toolComponent={
           <>
             <div
@@ -89,6 +95,11 @@ export const DocumentDetail = ({ documentId }: { documentId: string }) => {
                       <Link2Icon height={16} width={16} color="white" />
                     </div>
                   </UrlCopy>
+                  <LiveSimulationToggleButton
+                    enableLiveSimulation={enableLiveSimulation}
+                    setEnableLiveSimulation={setEnableLiveSimulation}
+                    title={t("liveSimulation")}
+                  />
                 </div>
                 <div className="text-lg">{document.name}</div>
               </div>

--- a/src/app/_components/toolbar/toolbar.tsx
+++ b/src/app/_components/toolbar/toolbar.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl";
 import { Button } from "../button/button";
 import type { EdgeType } from "@/app/_utils/kg/get-tree-layout-data";
 import { ZoomInIcon } from "../icons";
+import { LiveSimulationToggleButton } from "../view/graph-view/live-simulation-toggle-button";
+import { DirectedLinksToggleButton } from "../view/graph-view/directed-links-toggle-button";
 type ToolbarProps = {
   isLinkFiltered?: boolean;
   setIsLinkFiltered?: React.Dispatch<React.SetStateAction<boolean>>;
@@ -18,6 +20,10 @@ type ToolbarProps = {
   setEdgeType?: React.Dispatch<React.SetStateAction<EdgeType>>;
   magnifierMode?: number;
   setMagnifierMode?: React.Dispatch<React.SetStateAction<number>>;
+  enableLiveSimulation?: boolean;
+  setEnableLiveSimulation?: React.Dispatch<React.SetStateAction<boolean>>;
+  isDirectedLinks?: boolean;
+  setIsDirectedLinks?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export const Toolbar = ({
   isLinkFiltered,
@@ -32,6 +38,10 @@ export const Toolbar = ({
   setEdgeType,
   magnifierMode,
   setMagnifierMode,
+  enableLiveSimulation = false,
+  setEnableLiveSimulation,
+  isDirectedLinks = false,
+  setIsDirectedLinks,
 }: ToolbarProps) => {
   const t = useTranslations("view");
   const tGraph = useTranslations("graph");
@@ -39,6 +49,19 @@ export const Toolbar = ({
   return (
     <div className="flex h-[46px] w-full flex-row items-center justify-between">
       <div className="flex w-full flex-row items-center gap-4">
+        {!!setEnableLiveSimulation && (
+          <LiveSimulationToggleButton
+            enableLiveSimulation={enableLiveSimulation}
+            setEnableLiveSimulation={setEnableLiveSimulation}
+            title={t("liveSimulation")}
+          />
+        )}
+        {!!setIsDirectedLinks && (
+          <DirectedLinksToggleButton
+            isDirectedLinks={isDirectedLinks}
+            setIsDirectedLinks={setIsDirectedLinks}
+          />
+        )}
         {!!setMagnifierMode && magnifierMode !== undefined && (
           <button
             onClick={() => setMagnifierMode((prev) => (prev + 1) % 3)}

--- a/src/app/_components/view/graph-view/single-document-graph-viewer.tsx
+++ b/src/app/_components/view/graph-view/single-document-graph-viewer.tsx
@@ -86,6 +86,9 @@ export const SingleDocumentGraphViewer = ({ graphId }: { graphId: string }) => {
   const [currentScale, setCurrentScale] = useState<number>(1);
   const [textPanelFull, setTextPanelFull] = useState<boolean>(false);
   const [magnifierMode, setMagnifierMode] = useState(0);
+  const [enableLiveSimulation, setEnableLiveSimulation] =
+    useState<boolean>(true);
+  const [isDirectedLinks, setIsDirectedLinks] = useState<boolean>(true);
 
   const nodeId = searchParams.get("nodeId");
   const node = graphDocument?.nodes.find((n) => String(n.id) === nodeId);
@@ -138,6 +141,10 @@ export const SingleDocumentGraphViewer = ({ graphId }: { graphId: string }) => {
               setNodeSearchQuery={setNodeSearchQuery}
               magnifierMode={magnifierMode}
               setMagnifierMode={setMagnifierMode}
+              enableLiveSimulation={enableLiveSimulation}
+              setEnableLiveSimulation={setEnableLiveSimulation}
+              isDirectedLinks={isDirectedLinks}
+              setIsDirectedLinks={setIsDirectedLinks}
               rightArea={
                 <div className="flex flex-row items-center gap-4">
                   <button
@@ -241,6 +248,8 @@ export const SingleDocumentGraphViewer = ({ graphId }: { graphId: string }) => {
                 focusedLink={focusedLink}
                 isLargeGraph={false}
                 isEditor={isEditor}
+                isDirectedLinks={isDirectedLinks}
+                enableLiveSimulation={enableLiveSimulation}
                 onGraphUpdate={isEditor ? onGraphFormUpdate : undefined}
                 onNodeContextMenu={isEditor ? onNodeContextMenu : undefined}
                 onLinkContextMenu={isEditor ? onLinkContextMenu : undefined}

--- a/src/server/lib/extractors/base.ts
+++ b/src/server/lib/extractors/base.ts
@@ -53,53 +53,23 @@ export type CustomMappingRules = {
   mappings: MappingRule[];
 };
 
-export const ADDITIONAL_INSTRUCTION = `
-CRITICAL REQUIREMENT: For EVERY node extracted, you MUST provide BOTH name_ja and name_en properties.
-
-RULES:
-1. If a name appears in Japanese text, extract it as name_ja and translate it to English for name_en
-2. If a name appears in English text, extract it as name_en and translate it to Japanese for name_ja
-3. If a name appears in both languages, use the original text for the appropriate property
-4. For proper nouns (people, places, organizations), use official translations when available
-5. For concepts and terms, provide accurate translations that maintain meaning
-6. NEVER leave name_ja or name_en empty - always provide both properties
-7. Use consistent naming conventions (e.g., "ヨーゼフ・ボイス" for name_ja, "Joseph Beuys" for name_en)
-
-EXAMPLE:
-- Input: "ヨーゼフ・ボイスはドイツの芸術家です"
-- Output: { name_ja: "ヨーゼフ・ボイス", name_en: "Joseph Beuys" }
-
-- Input: "Joseph Beuys was a German artist"
-- Output: { name_ja: "ヨーゼフ・ボイス", name_en: "Joseph Beuys" }
-
-Relationships must be expressed in uppercase English (e.g., HAS_ROOMMATE, WORKS_AT, LOCATED_IN).
-`;
-
-const BASE_SYSTEM_PROMPT = `# Knowledge Graph Instructions for GPT-4
+const BASE_SYSTEM_PROMPT = `# Knowledge Graph Extraction Instructions
 ## 1. Overview
-You are a top-tier algorithm designed for extracting information in structured formats to build a knowledge graph.
-Try to capture as much information from the text as possible without sacrificing accuracy. Do not add any information that is not explicitly mentioned in the text
-- **Nodes** represent entities and concepts.
-- The aim is to achieve simplicity and clarity in the knowledge graph, making it accessible for a vast audience.
+You are a top-tier algorithm for extracting a knowledge graph from text.
+Capture as much information as possible WITHOUT sacrificing accuracy. Do not add information that is not explicitly stated or clearly implied by the text.
+- **Nodes** represent entities and concepts. Aim for a coherent and densely connected graph.
 
 ## 2. Labeling Nodes
-- **Consistency**: Ensure you use available types for node labels.
-Ensure you use basic or elementary types for node labels.
-- For example, when you identify an entity representing a person, always label it as **'person'**. Avoid using more specific terms like 'mathematician' or 'scientist'
-- **Node IDs**: Never utilize integers as node IDs. Node IDs should be names or human-readable identifiers found in the text.
-- **Relationships** represent connections between entities or concepts.
-Ensure consistency and generality in relationship types when constructing knowledge graphs. Instead of using specific and momentary types such as 'BECAME_PROFESSOR', use more general and timeless relationship types like 'PROFESSOR'. Make sure to use general and timeless relationship types!
+- Use basic, general labels (e.g., Person, Organization, Place, Event, Concept, Publication). Avoid overly specific labels such as 'Mathematician' or 'Scientist'.
+- **Node IDs**: Node IDs must be the human-readable name found in the text. For Japanese source text, use the original Japanese surface form as the node ID. Never use integers as node IDs.
 
-## 3. Properties Format
-- **CRITICAL**: When returning node or relationship properties, you MUST format them as an array of objects with "key" and "value" fields.
-- Example: properties must be an array like: [{{key: "name", value: "Alice"}}, {{key: "age", value: "25"}}]
-- DO NOT use object notation like {{name: "Alice", age: "25"}} - this will cause errors.
-- All property values must be strings.
+## 3. Relationships (IMPORTANT)
+- Be EXHAUSTIVE: extract ALL meaningful relationships that are stated or clearly implied between entities. Do NOT leave entities isolated when the text connects them.
+- If two entities appear together in an interaction, affiliation, location, participation, founding, influence, authorship, or similar, create a relationship between them.
+- Use general and timeless relationship types in UPPER_SNAKE_CASE English (e.g., LOCATED_IN, FOUNDED, PARTICIPATED_IN, COLLABORATES_WITH). Avoid specific and momentary types such as 'BECAME_PROFESSOR'.
 
 ## 4. Coreference Resolution
-- **Maintain Entity Consistency**: When extracting entities, it's vital to ensure consistency.
-If an entity, such as "John Doe", is mentioned multiple times in the text but is referred to by different names or pronouns (e.g., "Joe", "he"), always use the most complete identifier for that entity throughout the knowledge graph. In this example, use "John Doe" as the entity ID.
-Remember, the knowledge graph should be coherent and easily understandable, so maintaining consistency in entity references is crucial.`;
+- **Maintain Entity Consistency**: If an entity is mentioned multiple times but referred to by different names or pronouns (e.g., "Joe", "he"), always use its most complete identifier as the node ID throughout the graph (e.g., "John Doe").`;
 
 /**
  * LangChainのプロンプトテンプレートで中括弧をエスケープする
@@ -118,9 +88,6 @@ export function buildSystemPrompt(options: {
 
   let systemPrompt = BASE_SYSTEM_PROMPT;
 
-  systemPrompt += `\n\n## ${contextualInfo ? "5" : "4"}. Additional Requirements
-${escapeBraces(ADDITIONAL_INSTRUCTION)}`;
-
   if (mappingPrompt) {
     systemPrompt += `\n${mappingPrompt}`;
   }
@@ -130,12 +97,9 @@ ${escapeBraces(ADDITIONAL_INSTRUCTION)}`;
   }
 
   if (contextualInfo) {
-    systemPrompt += `\n\n## 6. Contextual Refinement
+    systemPrompt += `\n\n## 5. Contextual Refinement
 ${escapeBraces(contextualInfo)}`;
   }
-
-  systemPrompt += `\n\n## ${contextualInfo ? "7" : "6"}. Strict Compliance
-Adhere to the rules strictly. Non-compliance will result in termination.`;
 
   return systemPrompt;
 }

--- a/src/server/lib/extractors/iterative-core.ts
+++ b/src/server/lib/extractors/iterative-core.ts
@@ -52,7 +52,8 @@ function createChatModel(model: string, reasoningEffort: string): ChatOpenAI {
     return new ChatOpenAI({
       model,
       temperature: 1,
-      maxTokens: 16000,
+      // reasoning モデルでは maxTokens ではなく maxCompletionTokens が正式
+      maxCompletionTokens: 16000,
       modelKwargs: effort ? { reasoning_effort: effort } : undefined,
     });
   }
@@ -325,7 +326,7 @@ Maximize correct relationship coverage; duplicates are de-duplicated later.`;
 
         const sourceNode =
           finalNodes.find((n) => n.name === sourceName) ??
-          createExtraNode(sourceName, rel.source.type, finalNodes);
+          createExtraNode(sourceName, rel.source.type ?? "Entity", finalNodes);
 
         // Ensure sourceNode exists and is added to finalNodes if created via createExtraNode
         if (!finalNodes.find((n) => n.id === sourceNode.id)) {
@@ -334,7 +335,7 @@ Maximize correct relationship coverage; duplicates are de-duplicated later.`;
 
         const targetNode =
           finalNodes.find((n) => n.name === targetName) ??
-          createExtraNode(targetName, rel.target.type, finalNodes);
+          createExtraNode(targetName, rel.target.type ?? "Entity", finalNodes);
 
         // Ensure targetNode exists and is added to finalNodes if created via createExtraNode
         if (!finalNodes.find((n) => n.id === targetNode.id)) {

--- a/src/server/lib/extractors/iterative-core.ts
+++ b/src/server/lib/extractors/iterative-core.ts
@@ -20,26 +20,56 @@ import type {
 } from "node_modules/@langchain/community/dist/graphs/document";
 import type { Document } from "@langchain/core/documents";
 
-const PHASE1_MODEL = "gpt-4o";
-const PHASE2_MODEL = "gpt-4o-mini";
+// Phase1: 初期抽出。ノード/エッジの網羅性が品質を決める工程。
+// Phase2: 取りこぼした関係の補完。大規模文書でも安価に回したい工程。
+// gpt-4o / gpt-4o-mini は deprecated かつ、gpt-4o-mini は structured output で
+// 空を返す不具合が確認されたため、コスト最適な GPT-5.4 mini/nano を既定とする。
+// いずれも環境変数で上書き可能。
+const PHASE1_MODEL = process.env.KG_PHASE1_MODEL ?? "gpt-5.4-mini";
+const PHASE2_MODEL = process.env.KG_PHASE2_MODEL ?? "gpt-5.4-nano";
+// reasoning 系モデルの推論強度。コスト・レイテンシ抑制のため既定は "low"。
+// 有効値: none | low | medium | high | xhigh(モデル依存)。空文字ならモデル既定に委ねる。
+// ※ GPT-5.4 系は "minimal" 非対応(none/low/medium/high/xhigh のみ)。
+const PHASE1_REASONING_EFFORT = process.env.KG_PHASE1_REASONING_EFFORT ?? "low";
+const PHASE2_REASONING_EFFORT = process.env.KG_PHASE2_REASONING_EFFORT ?? "low";
 const FALLBACK_RELATIONSHIP_TYPE = "RELATED_TO";
 const EMPTY_GRAPH: NodesAndRelationships = { nodes: [], relationships: [] };
+
+/** reasoning 系(GPT-5 / o シリーズ)は temperature 固定(=1)かつ reasoning_effort を受け付ける。 */
+function isReasoningModel(model: string): boolean {
+  return /^(gpt-5|o\d)/i.test(model);
+}
+
+/**
+ * モデル名に応じて ChatOpenAI を生成する。
+ * reasoning 系は temperature=1 + reasoning_effort(modelKwargs 経由)を指定し、
+ * 非 reasoning 系(gpt-4.1 等)は低 temperature で決定的に抽出する。
+ * ※ reasoning_effort はコンストラクタの型に無いため modelKwargs で API へ直接渡す。
+ */
+function createChatModel(model: string, reasoningEffort: string): ChatOpenAI {
+  if (isReasoningModel(model)) {
+    const effort = reasoningEffort.trim();
+    return new ChatOpenAI({
+      model,
+      temperature: 1,
+      maxTokens: 16000,
+      modelKwargs: effort ? { reasoning_effort: effort } : undefined,
+    });
+  }
+  return new ChatOpenAI({
+    model,
+    temperature: 0.1,
+    maxTokens: 16000,
+  });
+}
 
 export class IterativeGraphExtractorCore {
   private phase1Llm: ChatOpenAI;
   private phase2Llm: ChatOpenAI;
 
   constructor() {
-    this.phase1Llm = new ChatOpenAI({
-      temperature: 0.1,
-      model: PHASE1_MODEL,
-      maxTokens: 16000,
-    });
-    this.phase2Llm = new ChatOpenAI({
-      temperature: 0.1,
-      model: PHASE2_MODEL,
-      maxTokens: 16000,
-    });
+    this.phase1Llm = createChatModel(PHASE1_MODEL, PHASE1_REASONING_EFFORT);
+    this.phase2Llm = createChatModel(PHASE2_MODEL, PHASE2_REASONING_EFFORT);
   }
 
   // Helper to build context string from frontend nodes
@@ -195,12 +225,14 @@ export class IterativeGraphExtractorCore {
 
     const mappingPrompt = buildMappingPrompt(customMappingRules);
     const fullContext = contextualInfo.trim()
-      ? `IMPORTANT: The following entities have already been identified in this text segment.
-Focus on finding relationships involving these entities that might have been missed in the first pass.
+      ? `The following entities were already identified in this text segment:
+${contextualInfo}
 
-EXISTING ENTITIES:
-${contextualInfo}`
-      : `IMPORTANT: Focus on finding relationships between entities mentioned in this text segment that might have been missed in the first pass.`;
+Re-read the text and extract ALL relationships among these entities and any additional entities you find.
+It is fine to include relationships that may already exist; duplicates are de-duplicated later.
+Maximize correct relationship coverage.`
+      : `Re-read the text and extract ALL relationships among the entities mentioned.
+Maximize correct relationship coverage; duplicates are de-duplicated later.`;
 
     const systemPrompt = buildSystemPrompt({
       mappingPrompt,
@@ -244,38 +276,56 @@ ${contextualInfo}`
 
     for (const doc of docs) {
       for (const node of doc.nodes) {
-        if (!allNodesMap.has(node.id.toString())) {
-          allNodesMap.set(node.id.toString(), node);
+        if (node.id === null || node.id === undefined) continue;
+        const key = node.id.toString();
+        if (key.trim() === "") continue;
+        if (!allNodesMap.has(key)) {
+          allNodesMap.set(key, node);
         }
       }
       allRelationships.push(...doc.relationships);
     }
 
+    // LLM が稀に id(=ノード名)が空/undefined のノード・関係を返すため、
+    // name を必ず非空文字列に正規化し、無効なものはスキップする(finalizeGraph の Zod 検証対策)。
+    const toName = (value: unknown): string =>
+      value === null || value === undefined ? "" : String(value).trim();
+
     const finalNodesRaw = Array.from(allNodesMap.values());
-    const finalNodes: NodeTypeForFrontend[] = finalNodesRaw.map((n) => {
-      const allProperties = n.properties || {};
-      const properties: Record<string, string> = {};
+    const finalNodes: NodeTypeForFrontend[] = finalNodesRaw
+      .map((n) => {
+        const allProperties = n.properties || {};
+        const properties: Record<string, string> = {};
 
-      for (const [key, value] of Object.entries(allProperties)) {
-        properties[key] = String(value ?? "");
-      }
+        for (const [key, value] of Object.entries(allProperties)) {
+          properties[key] = String(value ?? "");
+        }
 
-      if (!properties.name_ja) properties.name_ja = "";
-      if (!properties.name_en) properties.name_en = "";
+        if (!properties.name_ja) properties.name_ja = "";
+        if (!properties.name_en) properties.name_en = "";
 
-      return {
-        id: createId(),
-        name: n.id as string,
-        label: n.type,
-        properties,
-      };
-    });
+        return {
+          id: createId(),
+          name: toName(n.id),
+          label: n.type,
+          properties,
+        };
+      })
+      .filter((n) => n.name !== "");
 
     const finalRelationships: RelationshipTypeForFrontend[] =
-      allRelationships.map((rel) => {
+      allRelationships.flatMap((rel) => {
+        const sourceName = toName(rel.source?.id);
+        const targetName = toName(rel.target?.id);
+
+        // 端点の名前が無い関係は有効なノードを特定できないためスキップ
+        if (sourceName === "" || targetName === "") {
+          return [];
+        }
+
         const sourceNode =
-          finalNodes.find((n) => n.name === rel.source.id) ??
-          createExtraNode(rel.source.id as string, rel.source.type, finalNodes);
+          finalNodes.find((n) => n.name === sourceName) ??
+          createExtraNode(sourceName, rel.source.type, finalNodes);
 
         // Ensure sourceNode exists and is added to finalNodes if created via createExtraNode
         if (!finalNodes.find((n) => n.id === sourceNode.id)) {
@@ -283,8 +333,8 @@ ${contextualInfo}`
         }
 
         const targetNode =
-          finalNodes.find((n) => n.name === rel.target.id) ??
-          createExtraNode(rel.target.id as string, rel.target.type, finalNodes);
+          finalNodes.find((n) => n.name === targetName) ??
+          createExtraNode(targetName, rel.target.type, finalNodes);
 
         // Ensure targetNode exists and is added to finalNodes if created via createExtraNode
         if (!finalNodes.find((n) => n.id === targetNode.id)) {
@@ -298,13 +348,15 @@ ${contextualInfo}`
           relProperties[key] = String(value ?? "");
         }
 
-        return {
-          id: createId(),
-          sourceId: sourceNode.id,
-          targetId: targetNode.id,
-          type: rel.type,
-          properties: relProperties,
-        };
+        return [
+          {
+            id: createId(),
+            sourceId: sourceNode.id,
+            targetId: targetNode.id,
+            type: rel.type,
+            properties: relProperties,
+          },
+        ];
       });
 
     // Debug logging to check for data integrity


### PR DESCRIPTION
## 概要
知識グラフ(KG)の反復抽出パイプラインについて、実機(ローカルUI)で発生していた2件のエラー修正と、抽出品質向上のためのプロンプト刷新を行いました。

## 変更点
- **モデル設定の env 化 / reasoning_effort 修正** (`iterative-core.ts`, `.env.example`)
  - Phase1/Phase2 のモデルを環境変数で設定可能に(既定 `gpt-5.4-mini` / `gpt-5.4-nano`)。
  - `reasoning_effort` を有効値 `low` に変更(GPT-5.4 系は `minimal` を受け付けず `400 Unsupported value` になっていた)。空文字ならモデル既定に委ねる。
- **finalize の堅牢化** (`iterative-core.ts` `convertToFrontendFormat`)
  - 抽出量増加に伴い LLM が稀に `id`(=ノード名)が空/undefined の関係を返し、`name: undefined` のノードが生成され `finalizeGraph` の Zod 検証(`nodes[N].name` required)で全体が失敗していた。
  - ノード名を必ず非空文字列に正規化し、端点が空の関係はスキップ。`allNodesMap` 生成時も無効な id をガード。
- **抽出プロンプト V2** (`base.ts`)
  - スキーマと矛盾する指示・威圧的文言を削除し、日本語ノードID・網羅的な関係抽出を明示。

## 補足
- 検証用の診断スクリプト(`scripts/diagnose-*.ts`)は本PRに含めず削除済み。
- `npm run build` 成功を確認済み。

## テスト観点
- [ ] ローカルUIで1万字超の日本語テキストを投入し、Phase1/2 → finalize がエラーなく完了
- [ ] 抽出ノード/エッジ数が従来より増加していること

Made with [Cursor](https://cursor.com)