### PR TITLE
Fix cross-language node identity and improve graph editing UX

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -338,6 +338,7 @@
     "fullGraph": "Full graph",
     "recordingSvgFetchFailed": "Failed to get SVG element",
     "unknownError": "Unknown error",
+    "integrateFailed": "Failed to apply the graph",
     "annotationMap": {
       "group": "Group: {title}",
       "type": "Type: {type}",
@@ -487,6 +488,9 @@
     "replyCount": "{count} replies",
     "viewAllReplies": "View all replies ( + {more} more)",
     "searchingReferences": "Searching for references...",
+    "searchingOtherReferences": "Searching other documents...",
+    "provenanceReferencesHeading": "Source documents",
+    "otherReferencesHeading": "Other documents",
     "referenceFetchError": "An error occurred while fetching references.",
     "noReferencesFound": "No references found for \"{name}\".",
     "mentionedInDocuments": "Mentioned in {count} documents",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -338,6 +338,7 @@
     "fullGraph": "グラフ全体",
     "recordingSvgFetchFailed": "SVG要素の取得に失敗しました",
     "unknownError": "不明なエラー",
+    "integrateFailed": "グラフの反映に失敗しました",
     "annotationMap": {
       "group": "グループ: {title}",
       "type": "タイプ: {type}",
@@ -487,6 +488,9 @@
     "replyCount": "{count}件の返信",
     "viewAllReplies": "すべての返信を見る ( + {more} 件)",
     "searchingReferences": "引用箇所を検索中...",
+    "searchingOtherReferences": "その他のドキュメントを検索中...",
+    "provenanceReferencesHeading": "ソースドキュメント",
+    "otherReferencesHeading": "その他のドキュメント",
     "referenceFetchError": "引用箇所の取得中にエラーが発生しました。",
     "noReferencesFound": "「{name}」に関する引用箇所が見つかりませんでした。",
     "mentionedInDocuments": "{count}個のドキュメントで言及されています",

--- a/src/app/_components/article/public-article-viewer.tsx
+++ b/src/app/_components/article/public-article-viewer.tsx
@@ -16,6 +16,7 @@ import { CrossLargeIcon, GraphIcon, ZoomInIcon } from "../icons";
 import Image from "next/image";
 import { findEntityHighlights } from "@/app/_utils/text/find-entity-highlights";
 import { filterGraphByEntityNames } from "@/app/_utils/kg/filter-graph-by-entity-names";
+import { nodeMatchesName } from "@/app/_utils/kg/node-name-match";
 import { select, zoomTransform, pointer, zoom } from "d3";
 import type * as d3 from "d3";
 import { BottomSheet } from "../modal/bottom-sheet";
@@ -232,8 +233,8 @@ export const PublicArticleViewer: React.FC<PublicArticleViewerProps> = ({
 
   const handleEntityClick = (entityName: string) => {
     if (!graphDocument) return;
-    const foundNode = graphDocument.nodes.find(
-      (n: CustomNodeType) => n.name === entityName,
+    const foundNode = graphDocument.nodes.find((n: CustomNodeType) =>
+      nodeMatchesName(n, entityName),
     );
     if (foundNode) {
       setActiveEntity(foundNode);

--- a/src/app/_components/curators-writing-workspace/curators-writing-workspace.tsx
+++ b/src/app/_components/curators-writing-workspace/curators-writing-workspace.tsx
@@ -46,6 +46,7 @@ import { Modal } from "../modal/modal";
 import { useGraphEditor } from "@/app/_hooks/use-graph-editor";
 import { createSubgraphFromSelectedNodes } from "@/app/_utils/kg/create-subgraph-from-selected-nodes";
 import { filterGraphByEntityNames } from "@/app/_utils/kg/filter-graph-by-entity-names";
+import { nodeMatchesName } from "@/app/_utils/kg/node-name-match";
 import { filterGraphByLayoutInstruction } from "@/app/_utils/kg/filter-graph-by-layout-instruction";
 import { getSegmentNodeIdsFromMetaGraphStoryData } from "@/app/_utils/story-scroll-utils";
 import {
@@ -503,7 +504,9 @@ const CuratorsWritingWorkspace = ({
 
   // エンティティ名のクリック処理
   const handleEntityClick = (entityName: string) => {
-    const foundNode = nodes.find((n: CustomNodeType) => n.name === entityName);
+    const foundNode = nodes.find((n: CustomNodeType) =>
+      nodeMatchesName(n, entityName),
+    );
     if (foundNode) {
       updateActiveEntity(foundNode);
     }

--- a/src/app/_components/curators-writing-workspace/tiptap/tools/additional-graph-extraction-modal.tsx
+++ b/src/app/_components/curators-writing-workspace/tiptap/tools/additional-graph-extraction-modal.tsx
@@ -8,6 +8,7 @@ import type {
   GraphDocumentForFrontend,
 } from "@/app/const/types";
 import { storageUtils } from "@/app/_utils/supabase/supabase";
+import { nodesShareName } from "@/app/_utils/kg/node-name-match";
 import { BUCKETS } from "@/app/_utils/supabase/const";
 import { Loading } from "@/app/_components/loading/loading";
 import AdditionalGraphViewer from "@/app/_components/view/graph-view/additional-graph-viewer";
@@ -54,23 +55,6 @@ export const AdditionalGraphExtractionModal: React.FC<
     useEffect(() => {
       if (extractedGraph != null) setDisplayGraph(extractedGraph);
     }, [extractedGraph]);
-
-    const mergeIntoDisplayGraph = (
-      prev: GraphDocumentForFrontend | null,
-      additional: GraphDocumentForFrontend,
-    ): GraphDocumentForFrontend => {
-      if (!prev) return additional;
-      return {
-        nodes: [
-          ...(prev.nodes ?? []),
-          ...(additional.nodes?.map((n) => ({ ...n, isAdditional: true })) ?? []),
-        ],
-        relationships: [
-          ...(prev.relationships ?? []),
-          ...(additional.relationships?.map((r) => ({ ...r, isAdditional: true })) ?? []),
-        ],
-      };
-    };
 
     const extractKG = api.kg.extractKG.useMutation();
 
@@ -192,7 +176,7 @@ export const AdditionalGraphExtractionModal: React.FC<
       extractedGraph.nodes.forEach((extractedNode) => {
         const matchingEntity = existingEntities.find(
           (entity) =>
-            entity.name === extractedNode.name &&
+            nodesShareName(entity, extractedNode) &&
             entity.label === extractedNode.label,
         );
 
@@ -330,16 +314,6 @@ export const AdditionalGraphExtractionModal: React.FC<
                       }
                     }}
                     hideConfirmButton
-                    additionalGraph={undefined}
-                    setAdditionalGraph={(action) => {
-                      const additional =
-                        typeof action === "function" ? action(undefined) : action;
-                      if (additional != null) {
-                        setDisplayGraph((prev) =>
-                          mergeIntoDisplayGraph(prev, additional),
-                        );
-                      }
-                    }}
                   />
                 )}
                 {activeTab === "list" && (

--- a/src/app/_components/d3/extension/drag-editor-extension.tsx
+++ b/src/app/_components/d3/extension/drag-editor-extension.tsx
@@ -59,6 +59,33 @@ export const dragEditorExtension = ({
     return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
   };
 
+  // ドラッグ元イベントの DOM ターゲットから data-node-id を辿り、対象ノードを特定する。
+  // 座標距離での判定はノード端クリックやズーム倍率でズレるため、DOM 由来で確実に解決する。
+  const resolveNodeFromEvent = (
+    event: D3DragEvent<SVGCircleElement, CustomNodeType, CustomNodeType>,
+  ): CustomNodeType | null => {
+    const sourceEvent: unknown = event.sourceEvent;
+    if (!(sourceEvent instanceof Event)) return null;
+    const target = sourceEvent.target;
+    if (!(target instanceof Element)) return null;
+    const nodeEl = target.closest(`.${graphIdentifier}-node`);
+    const nodeId = nodeEl
+      ?.querySelector("[data-node-id]")
+      ?.getAttribute("data-node-id");
+    if (!nodeId) return null;
+    return graphDocument.nodes.find((node) => node.id === nodeId) ?? null;
+  };
+
+  // ズーム（パン）へイベントが伝播しないようにする。
+  const stopSourceEventPropagation = (
+    event: D3DragEvent<SVGCircleElement, CustomNodeType, CustomNodeType>,
+  ) => {
+    const sourceEvent: unknown = event.sourceEvent;
+    if (sourceEvent instanceof Event) {
+      sourceEvent.stopPropagation();
+    }
+  };
+
   // 新しいノードを追加する関数
   const addNewNode = (
     targetX: number,
@@ -128,23 +155,16 @@ export const dragEditorExtension = ({
   function dragStarted(
     event: D3DragEvent<SVGCircleElement, CustomNodeType, CustomNodeType>,
   ) {
-    simulation.stop();
-
-    // ドラッグ開始時のノードを特定
-    const sourceNode = graphDocument.nodes.find((node) => {
-      if (node.id === dragStateInExtension.sourceNode?.id) return false;
-
-      // 位置情報がない場合はスキップ
-      if (!("x" in node) || !("y" in node)) return false;
-
-      const nodeX = (node as CustomNodeType).x ?? 0;
-      const nodeY = (node as CustomNodeType).y ?? 0;
-      return distance(event.x, event.y, nodeX, nodeY) < 5;
-    });
+    // ドラッグ開始時のノードを DOM から特定
+    const sourceNode = resolveNodeFromEvent(event);
 
     if (!sourceNode) {
       return;
     }
+
+    // ズーム（パン）に取られないようにイベント伝播を止める
+    stopSourceEventPropagation(event);
+    simulation.stop();
 
     dragSet({
       isDragging: true,
@@ -152,30 +172,30 @@ export const dragEditorExtension = ({
       targetNode: null,
     });
 
-    event.subject.fx = event.subject.x;
-    event.subject.fy = event.subject.y;
+    const startX = sourceNode.x ?? event.x;
+    const startY = sourceNode.y ?? event.y;
 
     // 一時的な線を表示
     if (tempLineRef.current) {
       tempLineRef.current.style.display = "block";
-      tempLineRef.current.setAttribute("x1", String(event.subject.x));
-      tempLineRef.current.setAttribute("y1", String(event.subject.y));
-      tempLineRef.current.setAttribute("x2", String(event.subject.x));
-      tempLineRef.current.setAttribute("y2", String(event.subject.y));
+      tempLineRef.current.setAttribute("x1", String(startX));
+      tempLineRef.current.setAttribute("y1", String(startY));
+      tempLineRef.current.setAttribute("x2", String(startX));
+      tempLineRef.current.setAttribute("y2", String(startY));
     }
     if (tempCircleRef.current) {
       tempCircleRef.current.style.display = "block";
-      tempCircleRef.current.setAttribute("cx", String(event.subject.x));
-      tempCircleRef.current.setAttribute("cy", String(event.subject.y));
+      tempCircleRef.current.setAttribute("cx", String(startX));
+      tempCircleRef.current.setAttribute("cy", String(startY));
     }
   }
 
   function dragged(
     event: D3DragEvent<SVGCircleElement, CustomNodeType, CustomNodeType>,
   ) {
-    event.subject.fx = event.x;
-    event.subject.fy = event.y;
+    if (!dragStateInExtension.sourceNode) return;
 
+    stopSourceEventPropagation(event);
     simulation.stop();
 
     // targetNodeを更新
@@ -249,9 +269,6 @@ export const dragEditorExtension = ({
 
     // ドラッグ状態をリセット
     dragReset();
-
-    event.subject.fx = null;
-    event.subject.fy = null;
   }
 
   d3.selectAll<Element, unknown>(`.${graphIdentifier}-node`).call(

--- a/src/app/_components/d3/extension/drag-editor-extension.tsx
+++ b/src/app/_components/d3/extension/drag-editor-extension.tsx
@@ -16,7 +16,7 @@ export const dragEditorExtension = ({
   tempLineRef,
   tempCircleRef,
   simulation,
-  graphDocument,
+  getGraphDocument,
   dragState,
   setDragState,
   onGraphUpdate,
@@ -26,7 +26,12 @@ export const dragEditorExtension = ({
   tempLineRef: React.RefObject<SVGLineElement>;
   tempCircleRef: React.RefObject<SVGCircleElement>;
   simulation: Simulation<CustomNodeType, CustomLinkType>;
-  graphDocument: GraphDocumentForFrontend;
+  /**
+   * 最新の graphDocument を返す getter。
+   * ドラッグハンドラはアタッチ後も長く生存するため、スナップショットを閉じ込めると
+   * 構造更新後に古いデータを参照してしまう（stale closure）。ドラッグ時に都度最新を読む。
+   */
+  getGraphDocument: () => GraphDocumentForFrontend;
   dragState: DragState;
   setDragState: React.Dispatch<React.SetStateAction<DragState>>;
   onGraphUpdate?: (additionalGraph: GraphDocumentForFrontend) => void;
@@ -73,7 +78,7 @@ export const dragEditorExtension = ({
       ?.querySelector("[data-node-id]")
       ?.getAttribute("data-node-id");
     if (!nodeId) return null;
-    return graphDocument.nodes.find((node) => node.id === nodeId) ?? null;
+    return getGraphDocument().nodes.find((node) => node.id === nodeId) ?? null;
   };
 
   // ズーム（パン）へイベントが伝播しないようにする。
@@ -199,7 +204,7 @@ export const dragEditorExtension = ({
     simulation.stop();
 
     // targetNodeを更新
-    const targetNode = graphDocument.nodes.find((node) => {
+    const targetNode = getGraphDocument().nodes.find((node) => {
       if (node.id === dragStateInExtension.sourceNode?.id) return false;
 
       // 位置情報がない場合はスキップ

--- a/src/app/_components/d3/force/graph-info-panel.tsx
+++ b/src/app/_components/d3/force/graph-info-panel.tsx
@@ -17,7 +17,6 @@ import {
   DisclosurePanel,
 } from "@headlessui/react";
 import type { GraphDocumentForFrontend } from "@/app/const/types";
-import { usePathname, useRouter } from "i18n/navigation";
 import { getNodeByIdForFrontend } from "@/app/_utils/kg/filter";
 
 import { calculateGraphStatistics } from "@/app/_utils/kg/graph-statistics";
@@ -447,34 +446,20 @@ export const PropertiesSummaryPanel = ({
   node,
   contextId,
   contextType,
-  withDetail = false,
   onEditNode,
 }: {
   node: CustomNodeType;
   contextId: string;
   contextType: "topicSpace" | "document";
-  withDetail?: boolean;
   /** リストからノード編集モーダルを開く場合に指定（「詳細」と同様のボタンで編集を開く） */
   onEditNode?: (node: CustomNodeType) => void;
 }) => {
   const t = useTranslations("graph");
-  const router = useRouter();
-  const pathname = usePathname();
 
   return (
     <div className="flex flex-col gap-1">
       <div className="flex flex-row items-center gap-2">
         <div className="text-xs">{t("properties")}</div>
-        {withDetail && (
-          <Button
-            className="!p-1 !text-sm"
-            onClick={() =>
-              router.push(`${pathname}?list=true&nodeId=${node.id}`)
-            }
-          >
-            {t("detail")}
-          </Button>
-        )}
         {onEditNode && (
           <button
             type="button"
@@ -506,6 +491,7 @@ export const PropertiesSummaryPanel = ({
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline hover:no-underline"
+                  onClick={(e) => e.stopPropagation()}
                 >
                   {value}
                 </a>
@@ -517,6 +503,7 @@ export const PropertiesSummaryPanel = ({
                       target="_blank"
                       rel="noopener noreferrer"
                       className="underline hover:no-underline"
+                      onClick={(e) => e.stopPropagation()}
                     >
                       {value}
                     </a>

--- a/src/app/_components/d3/force/graph.tsx
+++ b/src/app/_components/d3/force/graph.tsx
@@ -1035,7 +1035,9 @@ export const D3ForceGraph = ({
   );
 
   // 直感編集で参照する値は ref 経由で最新を読む（毎レンダーで参照が変わる
-  // onGraphUpdate / graphDocument を依存に含めず、無駄な再アタッチを防ぐ）
+  // onGraphUpdate / graphDocument を依存に含めず、無駄な再アタッチを防ぐ）。
+  // ドラッグハンドラはアタッチ後も生存するため、graphDocument はスナップショットで
+  // 閉じ込めず getter 経由でドラッグ時に最新を読む（構造更新後の stale closure を防止）。
   const onGraphUpdateRef = useRef(onGraphUpdate);
   onGraphUpdateRef.current = onGraphUpdate;
   const graphDocumentRef = useRef(graphDocument);
@@ -1053,7 +1055,7 @@ export const D3ForceGraph = ({
       tempLineRef,
       tempCircleRef,
       simulation,
-      graphDocument: graphDocumentRef.current,
+      getGraphDocument: () => graphDocumentRef.current,
       dragState,
       setDragState,
       onGraphUpdate: (additionalGraph) =>

--- a/src/app/_components/d3/force/graph.tsx
+++ b/src/app/_components/d3/force/graph.tsx
@@ -10,6 +10,7 @@ import {
   forceX,
   forceY,
   forceCollide,
+  selectAll,
   type ForceLink,
 } from "d3";
 import { useCallback, useEffect, useMemo, useRef, useState, memo } from "react";
@@ -98,6 +99,7 @@ type GraphNodeCircleProps = {
   isAddedInHistory: boolean;
   isRemovedInHistory: boolean;
   isMergeTarget: boolean;
+  isNewlyAdded: boolean;
   isAdditional: boolean;
   isExistingContext: boolean;
   nodeColor?: string;
@@ -136,6 +138,7 @@ function graphNodeCirclePropsAreEqual(
     prev.isAddedInHistory === next.isAddedInHistory &&
     prev.isRemovedInHistory === next.isRemovedInHistory &&
     prev.isMergeTarget === next.isMergeTarget &&
+    prev.isNewlyAdded === next.isNewlyAdded &&
     prev.isAdditional === next.isAdditional &&
     prev.isExistingContext === next.isExistingContext &&
     prev.nodeColor === next.nodeColor &&
@@ -169,6 +172,7 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
   isAddedInHistory,
   isRemovedInHistory,
   isMergeTarget,
+  isNewlyAdded,
   isAdditional,
   isExistingContext,
   nodeColor,
@@ -215,13 +219,15 @@ const GraphNodeCircle = memo(function GraphNodeCircle({
             ? "#ef4444"
             : isMergeTarget
               ? "#10b981"
-              : isAdditional
-                ? "#8b9dc3"
-                : graphUnselected
-                  ? "#324557"
-                  : isClustered && nodeColor
-                    ? nodeColor
-                    : "whitesmoke";
+              : isNewlyAdded
+                ? "#10b981"
+                : isAdditional
+                  ? "#8b9dc3"
+                  : graphUnselected
+                    ? "#324557"
+                    : isClustered && nodeColor
+                      ? nodeColor
+                      : "whitesmoke";
   const opacity =
     isExistingContext
       ? 0.3
@@ -444,6 +450,8 @@ export const D3ForceGraph = ({
 }) => {
   const t = useTranslations("graph");
   const nodeDragEnabled = enableNodeDrag ?? (!enableLiveSimulation && !isEditor);
+  // 直感編集が有効か（isEditor かつ onGraphUpdate あり）
+  const canEditGraph = isEditor && !!onGraphUpdate;
   const { nodes, relationships } = graphDocument;
   const initLinks = relationships as CustomLinkType[];
   const initNodes = isLinkFiltered ? linkFilter(nodes, initLinks) : nodes;
@@ -768,8 +776,10 @@ export const D3ForceGraph = ({
   useEffect(() => {
     const initNodes = initNodesRef.current;
     const newLinks = newLinksRef.current;
-    // width/heightが無効な値の場合はシミュレーションを初期化しない
-    if (width <= 0 || height <= 0 || !initNodes.length || !newLinks.length) {
+    // width/heightが無効、またはノードが存在しない場合はシミュレーションを初期化しない。
+    // リンクが1本もないグラフ（孤立ノードのみ）でも forceCenter 等で中央に配置するため、
+    // リンク数の条件はガードに含めない（含めると孤立ノードが座標未設定(0,0)のままになる）。
+    if (width <= 0 || height <= 0 || !initNodes.length) {
       return;
     }
 
@@ -940,20 +950,6 @@ export const D3ForceGraph = ({
       settleLayout();
     });
 
-    if (isEditor && !!onGraphUpdate && !!dragState) {
-      dragEditorExtension({
-        tempLineRef,
-        tempCircleRef,
-        simulation,
-        graphDocument,
-        dragState,
-        setDragState,
-        onGraphUpdate,
-        graphIdentifier,
-        formatNewNodeName: (id) => t("newNodeName", { id }),
-      });
-    }
-
     return () => {
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);
@@ -1024,6 +1020,59 @@ export const D3ForceGraph = ({
     graphNodes.length,
     handleNodeDragPositionChange,
     svgRef,
+  ]);
+
+  // 実際に描画されているノード数（ドラッグ編集ハンドラの再アタッチ判定に使用）。
+  // ライブシミュレーション中は graphNodes 参照が毎フレーム変わるが、この値は
+  // ノードの増減時のみ変化するため、無駄な再アタッチを避けられる。
+  const renderedNodeCount = useMemo(
+    () =>
+      graphNodes.reduce(
+        (acc, node) => acc + ((node.visible ?? false) ? 1 : 0),
+        0,
+      ),
+    [graphNodes],
+  );
+
+  // 直感編集で参照する値は ref 経由で最新を読む（毎レンダーで参照が変わる
+  // onGraphUpdate / graphDocument を依存に含めず、無駄な再アタッチを防ぐ）
+  const onGraphUpdateRef = useRef(onGraphUpdate);
+  onGraphUpdateRef.current = onGraphUpdate;
+  const graphDocumentRef = useRef(graphDocument);
+  graphDocumentRef.current = graphDocument;
+
+  // 直感編集（ノードからのドラッグでエッジ／ノードを追加）のドラッグハンドラを、
+  // ノードの DOM 要素が描画された後に確実にアタッチする。
+  // （シミュレーション構築 effect 内では描画前のためアタッチできない）
+  useEffect(() => {
+    if (!canEditGraph) return;
+    const simulation = simulationRef.current;
+    if (!simulation || renderedNodeCount === 0) return;
+
+    dragEditorExtension({
+      tempLineRef,
+      tempCircleRef,
+      simulation,
+      graphDocument: graphDocumentRef.current,
+      dragState,
+      setDragState,
+      onGraphUpdate: (additionalGraph) =>
+        onGraphUpdateRef.current?.(additionalGraph),
+      graphIdentifier,
+      formatNewNodeName: (id) => t("newNodeName", { id }),
+    });
+
+    return () => {
+      selectAll<Element, unknown>(`.${graphIdentifier}-node`).on(".drag", null);
+    };
+    // dragState は毎ドラッグで変化するため依存に含めない（アタッチ時の初期値のみ使用）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    canEditGraph,
+    graphIdentifier,
+    renderedNodeCount,
+    simulationDataKey,
+    isLayoutSettled,
   ]);
 
   return (
@@ -1154,9 +1203,11 @@ export const D3ForceGraph = ({
                                     ? "#ef4444" // 変更履歴で削除されたエッジは赤色
                                     : isPathLink
                                       ? "#eae80c"
-                                      : graphLink.isAdditional
-                                        ? "#3769d4"
-                                        : "white"
+                                      : graphLink.isNewlyAdded
+                                        ? "#10b981" // 新規追加予定のエッジは緑色（ノードと統一）
+                                        : graphLink.isAdditional
+                                          ? "#3769d4"
+                                          : "white"
                           }
                           data-link-id={graphLink.id}
                           data-is-added={graphLink.isAddedInHistory}
@@ -1169,13 +1220,15 @@ export const D3ForceGraph = ({
                                 ? 1
                                 : isSelectionMode && isSelectedLink
                                   ? 0.9
-                                  : graphLink.isExistingContext
-                                    ? 0.2 // 既存グラフのコンテキストエッジは薄く
-                                    : isGradient
-                                      ? 0.04
-                                      : (distance(graphLink) ? 0.6 : 0.4) /
-                                      (distance(graphLink) *
-                                        distance(graphLink) || 1)
+                                  : graphLink.isNewlyAdded
+                                    ? 0.9 // 新規追加予定のエッジははっきり表示
+                                    : graphLink.isExistingContext
+                                      ? 0.2 // 既存グラフのコンテキストエッジは薄く
+                                      : isGradient
+                                        ? 0.04
+                                        : (distance(graphLink) ? 0.6 : 0.4) /
+                                          (distance(graphLink) *
+                                            distance(graphLink) || 1)
                           }
                           strokeWidth={
                             (graphLink.isAddedInHistory ??
@@ -1385,6 +1438,7 @@ export const D3ForceGraph = ({
                       isAddedInHistory={graphNode.isAddedInHistory ?? false}
                       isRemovedInHistory={graphNode.isRemovedInHistory ?? false}
                       isMergeTarget={graphNode.isMergeTarget ?? false}
+                      isNewlyAdded={graphNode.isNewlyAdded ?? false}
                       isAdditional={graphNode.isAdditional ?? false}
                       isExistingContext={graphNode.isExistingContext ?? false}
                       nodeColor={graphNode.nodeColor}
@@ -1447,6 +1501,7 @@ export const D3ForceGraph = ({
                       isAddedInHistory={graphNode.isAddedInHistory ?? false}
                       isRemovedInHistory={graphNode.isRemovedInHistory ?? false}
                       isMergeTarget={graphNode.isMergeTarget ?? false}
+                      isNewlyAdded={graphNode.isNewlyAdded ?? false}
                       isAdditional={graphNode.isAdditional ?? false}
                       isExistingContext={graphNode.isExistingContext ?? false}
                       nodeColor={graphNode.nodeColor}

--- a/src/app/_components/d3/tree/radial-tree.tsx
+++ b/src/app/_components/d3/tree/radial-tree.tsx
@@ -12,6 +12,7 @@ import {
 import { D3ZoomProvider } from "../zoom";
 import type { TreeNode } from "@/app/const/types";
 import type { GraphDocumentForFrontend } from "@/app/const/types";
+import { nodeMatchesName } from "@/app/_utils/kg/node-name-match";
 import { useRouter } from "i18n/navigation";
 
 type D3RadialTreeProps = {
@@ -78,7 +79,7 @@ export const D3RadialTree = ({
 
     const isSelected = (name: string) => {
       return selectedGraphData?.nodes.some((node) => {
-        return node.name === name;
+        return nodeMatchesName(node, name);
       });
     };
     const inSelected = (d: HierarchyPointNode<TreeNode>) =>

--- a/src/app/_components/input/tags-input.tsx
+++ b/src/app/_components/input/tags-input.tsx
@@ -13,7 +13,6 @@ type TagsInputProps = {
   setSelected: React.Dispatch<React.SetStateAction<TagOption | undefined>>;
   borderRed?: boolean;
   placeholder?: string;
-  defaultOption?: TagOption;
 };
 
 export const TagsInput = ({
@@ -21,7 +20,6 @@ export const TagsInput = ({
   selected,
   setSelected,
   placeholder,
-  defaultOption,
 }: TagsInputProps) => {
   const [query, setQuery] = useState("");
 
@@ -35,7 +33,6 @@ export const TagsInput = ({
   return (
     <Combobox
       value={selected}
-      defaultValue={defaultOption}
       // multiple
       onChange={(val) => {
         if (val) {

--- a/src/app/_components/list/node-link-list.tsx
+++ b/src/app/_components/list/node-link-list.tsx
@@ -115,6 +115,11 @@ export const NodeLinkList = ({
 
   const router = useRouter();
   const searchParams = useSearchParams();
+  const detailNodeId = searchParams.get("nodeId");
+
+  const openNodeDetail = (nodeId: string) => {
+    router.push(`?list=true&nodeId=${nodeId}`, { scroll: false });
+  };
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -211,17 +216,33 @@ export const NodeLinkList = ({
             nodeSearchQuery !== "" &&
             node.name.toLowerCase().includes(nodeSearchQuery.toLowerCase());
           const isCurrentMatch = currentMatchNode?.id === node.id;
+          const isDetailOpen = detailNodeId === String(node.id);
           return (
             <div
               key={node.id}
               ref={isCurrentMatch ? scrollTargetRef : undefined}
-              className={`flex w-full flex-row items-center p-2 ${focusedNode?.id === node.id
-                  ? "bg-slate-600"
-                  : queryFiltered
-                    ? isCurrentMatch
-                      ? "bg-slate-700 ring-2 ring-inset ring-orange-400"
-                      : "bg-slate-700"
-                    : ""
+              role="button"
+              tabIndex={isNodeMergeMode ? -1 : 0}
+              onClick={() => {
+                if (isNodeMergeMode) return;
+                openNodeDetail(node.id);
+              }}
+              onKeyDown={(e) => {
+                if (isNodeMergeMode) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openNodeDetail(node.id);
+                }
+              }}
+              className={`flex w-full flex-row items-center p-2 transition-colors ${isNodeMergeMode ? "" : "cursor-pointer"} ${isDetailOpen
+                  ? "bg-sky-950/60 ring-2 ring-inset ring-sky-400"
+                  : focusedNode?.id === node.id
+                    ? "bg-slate-600"
+                    : queryFiltered
+                      ? isCurrentMatch
+                        ? "bg-slate-700 ring-2 ring-inset ring-orange-400"
+                        : "bg-slate-700"
+                      : "hover:bg-slate-50/10"
                 }`}
             >
               {isNodeMergeMode && (
@@ -253,7 +274,6 @@ export const NodeLinkList = ({
                   node={node}
                   contextId={contextId}
                   contextType={contextType}
-                  withDetail={true}
                   onEditNode={isEditor ? onEditNode : undefined}
                 />
               </div>

--- a/src/app/_components/modal/node-link-edit-panel.tsx
+++ b/src/app/_components/modal/node-link-edit-panel.tsx
@@ -103,7 +103,6 @@ export const NodeLinkEditPanel = ({
                         "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
                       )}
                       value={node.name}
-                      defaultValue={node.name}
                       onChange={(e) => {
                         if (isFullGraphMode && graphDocument) {
                           setGraphDocument({
@@ -150,7 +149,6 @@ export const NodeLinkEditPanel = ({
                         "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
                       )}
                       value={node.label}
-                      defaultValue={node.label}
                       onChange={(e) => {
                         if (isFullGraphMode && graphDocument) {
                           setGraphDocument({
@@ -218,7 +216,6 @@ export const NodeLinkEditPanel = ({
                       "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
                     )}
                     value={relationship.type}
-                    defaultValue={relationship.type}
                     onChange={(e) => {
                       if (isFullGraphMode && graphDocument) {
                         setGraphDocument({

--- a/src/app/_components/modal/node-link-property-edit-modal.tsx
+++ b/src/app/_components/modal/node-link-property-edit-modal.tsx
@@ -73,7 +73,6 @@ export const NodePropertyEditModal = ({
                 "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
               )}
               value={graphNodeField.name}
-              defaultValue={graphNodeField.name}
               onChange={(e) => {
                 const newName = e.target.value;
                 setGraphNodeField({
@@ -98,7 +97,6 @@ export const NodePropertyEditModal = ({
                 "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
               )}
               value={graphNodeField.label}
-              defaultValue={graphNodeField.label}
               onChange={(e) => {
                 setGraphNodeField({
                   ...graphNodeField,
@@ -240,7 +238,6 @@ export const LinkPropertyEditModal = ({
               "focus:outline-none data-[focus]:outline-1 data-[focus]:-outline-offset-2 data-[focus]:outline-slate-400",
             )}
             value={graphLinkField.type}
-            defaultValue={graphLinkField.type}
             onChange={(e) => {
               setGraphLinkField({
                 ...graphLinkField,

--- a/src/app/_components/view/graph-view/additional-graph-viewer.tsx
+++ b/src/app/_components/view/graph-view/additional-graph-viewer.tsx
@@ -179,16 +179,25 @@ const AdditionalGraphViewer = ({
     });
 
     // 追加グラフのノードにフラグを付与
+    // - 既存グラフに存在するノード（mergeTargetNodeIds に含まれる）は「これまでに存在していたノード」→ 通常表示（白）
+    // - それ以外は「これから新しく追加されるノード」→ 緑で強調
     const annotatedNodes = newGraphDocument.nodes.map((node) => ({
       ...node,
-      isMergeTarget: mergeTargetNodeIds.has(node.id),
-      isExistingContext: false, // 新しく追加される予定のノードは通常表示
+      isMergeTarget: false,
+      isNewlyAdded: !mergeTargetNodeIds.has(node.id),
+      isExistingContext: false,
+    }));
+
+    // 抽出された（これから追加される）エッジは緑で強調（ノードと統一）
+    const annotatedRelationships = newGraphDocument.relationships.map((rel) => ({
+      ...rel,
+      isNewlyAdded: true,
     }));
 
     // 既存コンテキストノードとエッジを追加
     const allNodes = [...annotatedNodes, ...contextNodes];
     const allRelationships = [
-      ...newGraphDocument.relationships,
+      ...annotatedRelationships,
       ...contextRelationships,
     ];
 
@@ -379,6 +388,9 @@ const AdditionalGraphViewer = ({
     controlledAdditionalGraph ?? internalAdditionalGraph;
   const setAdditionalGraph =
     controlledSetAdditionalGraph ?? setInternalAdditionalGraph;
+  // 親が controlled な setAdditionalGraph を渡す（＝グラフ更新を即座に親stateへマージする）
+  // 場合はポップアップを使わない。それ以外（内部stateでの追加編集フロー）はポップアップを出す。
+  const usesControlledAdditionalGraph = controlledSetAdditionalGraph != null;
 
   const [isNodeLinkAttachModalOpen, setIsNodeLinkAttachModalOpen] =
     useState<boolean>(false);
@@ -389,7 +401,10 @@ const AdditionalGraphViewer = ({
   const onGraphUpdate = (nextAdditionalGraph: GraphDocumentForFrontend) => {
     console.log("onGraphUpdate", nextAdditionalGraph);
     setAdditionalGraph(nextAdditionalGraph);
-    if (!onConfirm) {
+    // controlled マージ利用時は即マージするためポップアップは出さない。
+    // それ以外（プレビュー含む内部stateフロー）は追加ノード・エッジの
+    // プロパティ編集ポップアップを開く。
+    if (!usesControlledAdditionalGraph) {
       setIsNodeLinkAttachModalOpen(true);
     }
   };
@@ -486,6 +501,7 @@ const AdditionalGraphViewer = ({
             graphDocument={annotatedGraphDocument}
             isEditor={true}
             isLargeGraph={false}
+            enableLiveSimulation={true}
             setFocusedLink={setFocusedLink}
             toolComponent={<></>}
             onGraphUpdate={onGraphUpdate}
@@ -495,7 +511,7 @@ const AdditionalGraphViewer = ({
           />
         )}
       </ContainerSizeProvider>
-      {!useConfirmButton && (
+      {!usesControlledAdditionalGraph && (
         <NodeLinkEditModal
           isOpen={isNodeLinkAttachModalOpen}
           setIsOpen={setIsNodeLinkAttachModalOpen}

--- a/src/app/_components/view/graph-view/graph-tool.tsx
+++ b/src/app/_components/view/graph-view/graph-tool.tsx
@@ -139,15 +139,6 @@ export const GraphTool = ({
               setSelected={setTags}
               options={tagOptions}
               placeholder={t("filterByTag")}
-              defaultOption={
-                tagFilterOption?.value && tagFilterOption?.type
-                  ? {
-                    id: "0",
-                    label: tagFilterOption.value,
-                    type: tagFilterOption.type,
-                  }
-                  : undefined
-              }
             />
           </div>
         ) : (

--- a/src/app/_components/view/graph-view/related-nodes-viewer.tsx
+++ b/src/app/_components/view/graph-view/related-nodes-viewer.tsx
@@ -95,6 +95,7 @@ export const RelatedNodesAndLinksViewer = ({
     >
       {isContainerReady ? (
         <D3ForceGraph
+          key={node.id}
           graphDocument={relatedNodesAndLinks}
           svgRef={svgRef}
           height={graphHeight}

--- a/src/app/_components/view/node/node-properties-detail.tsx
+++ b/src/app/_components/view/node/node-properties-detail.tsx
@@ -32,7 +32,9 @@ export const NodePropertiesDetail = ({
   const tGraph = useTranslations("graph");
   const router = useRouter();
   const pathname = usePathname();
+  const utils = api.useUtils();
   const extractKG = api.kg.extractKG.useMutation();
+  const integrateGraph = api.kg.integrateGraph.useMutation();
   const [isExtracting, setIsExtracting] = useState<boolean>(false);
   const [newGraphDocument, setNewGraphDocument] =
     useState<GraphDocumentForFrontend | null>(null);
@@ -83,6 +85,61 @@ export const NodePropertiesDetail = ({
   };
 
   const onGraphUpdate = (additionalGraph: GraphDocumentForFrontend) => {
+    // トピックスペースの詳細画面では、モーダルの「グラフに反映」で
+    // 抽出・編集したグラフを直接リポジトリの既存グラフへ統合する。
+    if (contextType === "topicSpace" && contextId) {
+      const graphDocumentToIntegrate = {
+        nodes: additionalGraph.nodes
+          .filter((node) => !node.id.startsWith("context-"))
+          .map((node) => ({
+            id: node.id,
+            name: node.name,
+            label: node.label,
+            properties: node.properties ?? {},
+          })),
+        relationships: additionalGraph.relationships
+          .filter(
+            (rel) =>
+              !rel.id.startsWith("context-") &&
+              !rel.sourceId.startsWith("context-") &&
+              !rel.targetId.startsWith("context-"),
+          )
+          .map((rel) => ({
+            id: rel.id,
+            type: rel.type,
+            properties: rel.properties ?? {},
+            sourceId: rel.sourceId,
+            targetId: rel.targetId,
+          })),
+      };
+
+      integrateGraph.mutate(
+        {
+          topicSpaceId: contextId,
+          graphDocument: graphDocumentToIntegrate,
+        },
+        {
+          onSuccess: () => {
+            setNewGraphDocument(null);
+            setIsGraphEditorMode(false);
+            refetch?.();
+            // Node詳細パネルの隣接グラフビュー（getRelatedNodes）を再取得して更新する
+            void utils.kg.getRelatedNodes.invalidate({
+              nodeId: node.id,
+              contextId,
+              contextType,
+            });
+          },
+          onError: (e) => {
+            console.error("グラフの統合に失敗しました", e);
+            alert(tGraph("integrateFailed"));
+          },
+        },
+      );
+      return;
+    }
+
+    // トピックスペース以外（ドキュメント等）は従来どおり編集ビューにステージングする。
     setNewGraphDocument(additionalGraph);
     setIsGraphEditorMode(true);
   };

--- a/src/app/_components/view/node/node-reference-panel.tsx
+++ b/src/app/_components/view/node/node-reference-panel.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { api } from "@/trpc/react";
 import type { CustomNodeType } from "@/app/const/types";
+import type { RouterOutputs } from "@/trpc/react";
 import { Link } from "i18n/navigation";
 import { useTranslations } from "next-intl";
 
@@ -11,26 +12,53 @@ interface NodeReferencePanelProps {
   topicSpaceId: string;
 }
 
+type ReferenceSections = RouterOutputs["topicSpaces"]["getNodeReference"];
+
 export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
   node,
   topicSpaceId,
 }) => {
   const t = useTranslations("view");
-  const {
-    data: nodeReferences,
-    isLoading,
-    error,
-  } = api.topicSpaces.getNodeReference.useQuery({
+
+  // 出自(provenance)ドキュメントの引用を先に取得・表示し、
+  // それ以外のドキュメントの引用は後から取得・追加表示する。
+  const provenanceQuery = api.topicSpaces.getNodeReference.useQuery({
     id: topicSpaceId,
     nodeId: node.id,
+    scope: "provenance",
+  });
+  const othersQuery = api.topicSpaces.getNodeReference.useQuery({
+    id: topicSpaceId,
+    nodeId: node.id,
+    scope: "others",
   });
 
-  const highlightText = (text: string, searchTerm: string) => {
-    if (!searchTerm) return text;
+  // ハイライト対象語: 表示名 + ローカライズ名(name_ja/name_en)
+  const highlightTerms = Array.from(
+    new Set(
+      [
+        node.name,
+        node.properties?.name_ja,
+        node.properties?.name_en,
+      ].filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim() !== "",
+      ),
+    ),
+  );
 
-    const regex = new RegExp(`(${searchTerm})`, "gi");
+  const escapeRegExp = (value: string) =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  const highlightText = (text: string) => {
+    if (highlightTerms.length === 0) return text;
+    const lowerTerms = highlightTerms.map((term) => term.toLowerCase());
+    const regex = new RegExp(
+      `(${highlightTerms.map(escapeRegExp).join("|")})`,
+      "gi",
+    );
     return text.split(regex).map((part, index) =>
-      regex.test(part) ? (
+      lowerTerms.includes(part.toLowerCase()) ? (
         <mark
           key={index}
           className="rounded bg-yellow-200 px-1 text-yellow-900"
@@ -38,20 +66,58 @@ export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
           {part}
         </mark>
       ) : (
-        part
+        <React.Fragment key={index}>{part}</React.Fragment>
       ),
     );
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-gray-400">{t("searchingReferences")}</div>
-      </div>
+  const filterNonEmpty = (references: ReferenceSections | undefined) =>
+    (references ?? []).filter(
+      (ref) => ref.relevantSections && ref.relevantSections.length > 0,
     );
-  }
 
-  if (error) {
+  const provenanceRefs = filterNonEmpty(provenanceQuery.data);
+  const otherRefs = filterNonEmpty(othersQuery.data);
+
+  const renderReferenceList = (references: ReferenceSections) => (
+    <div className="space-y-4">
+      {references.map((reference) => (
+        <div
+          key={reference.sourceDocument.id}
+          className="rounded-lg border border-slate-600 bg-slate-800/50 p-4"
+        >
+          <Link
+            href={reference.sourceDocument.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h4 className="mb-3 flex items-center font-semibold text-gray-200">
+              <span className="mr-2 h-2 w-2 rounded-full bg-blue-400"></span>
+              {reference.sourceDocument.name}
+            </h4>
+          </Link>
+
+          <div className="space-y-3">
+            {reference.relevantSections.map((section, index) => (
+              <div
+                key={index}
+                className="rounded bg-slate-700/50 p-3 text-sm leading-relaxed text-gray-300"
+              >
+                <div className="whitespace-pre-wrap">
+                  {highlightText(section)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  const bothDone = !provenanceQuery.isLoading && !othersQuery.isLoading;
+  const bothErrored = !!provenanceQuery.error && !!othersQuery.error;
+
+  if (bothErrored) {
     return (
       <div className="py-8 text-center text-red-400">
         <p>{t("referenceFetchError")}</p>
@@ -59,20 +125,11 @@ export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
     );
   }
 
-  if (!nodeReferences || nodeReferences.length === 0) {
-    return (
-      <div className="py-8 text-center text-gray-400">
-        <p>{t("noReferencesFound", { name: node.name })}</p>
-      </div>
-    );
-  }
-
-  // 空でない結果のみをフィルタリング
-  const filteredReferences = nodeReferences.filter(
-    (ref) => ref.relevantSections && ref.relevantSections.length > 0,
-  );
-
-  if (filteredReferences.length === 0) {
+  if (
+    bothDone &&
+    provenanceRefs.length === 0 &&
+    otherRefs.length === 0
+  ) {
     return (
       <div className="py-8 text-center text-gray-400">
         <p>{t("noReferencesFound", { name: node.name })}</p>
@@ -81,45 +138,50 @@ export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
   }
 
   return (
-    <div className="space-y-4">
-      <div className="mb-4">
-        <p className="mt-2 text-sm text-gray-400">
-          {t("mentionedInDocuments", { count: filteredReferences.length })}
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        {filteredReferences.map((reference) => (
-          <div
-            key={reference.sourceDocument.id}
-            className="rounded-lg border border-slate-600 bg-slate-800/50 p-4"
-          >
-            <Link
-              href={reference.sourceDocument.url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <h4 className="mb-3 flex items-center font-semibold text-gray-200">
-                <span className="mr-2 h-2 w-2 rounded-full bg-blue-400"></span>
-                {reference.sourceDocument.name}
-              </h4>
-            </Link>
-
-            <div className="space-y-3">
-              {reference.relevantSections.map((section, index) => (
-                <div
-                  key={index}
-                  className="rounded bg-slate-700/50 p-3 text-sm leading-relaxed text-gray-300"
-                >
-                  <div className="whitespace-pre-wrap">
-                    {highlightText(section, node.name)}
-                  </div>
-                </div>
-              ))}
+    <div className="space-y-6">
+      {/* 出自ドキュメント（先に表示） */}
+      {(provenanceQuery.isLoading || provenanceRefs.length > 0) && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-gray-300">
+            {t("provenanceReferencesHeading")}
+          </h3>
+          {provenanceQuery.isLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <div className="text-gray-400">{t("searchingReferences")}</div>
             </div>
-          </div>
-        ))}
-      </div>
+          ) : (
+            <>
+              <p className="text-xs text-gray-400">
+                {t("mentionedInDocuments", { count: provenanceRefs.length })}
+              </p>
+              {renderReferenceList(provenanceRefs)}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* その他のドキュメント（後から表示） */}
+      {(othersQuery.isLoading || otherRefs.length > 0) && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-gray-300">
+            {t("otherReferencesHeading")}
+          </h3>
+          {othersQuery.isLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <div className="text-gray-400">
+                {t("searchingOtherReferences")}
+              </div>
+            </div>
+          ) : (
+            <>
+              <p className="text-xs text-gray-400">
+                {t("mentionedInDocuments", { count: otherRefs.length })}
+              </p>
+              {renderReferenceList(otherRefs)}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/_components/view/node/node-reference-panel.tsx
+++ b/src/app/_components/view/node/node-reference-panel.tsx
@@ -34,6 +34,8 @@ export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
   });
 
   // ハイライト対象語: 表示名 + ローカライズ名(name_ja/name_en)
+  // 正規表現のオルタネーションで短い語が先にマッチして長い語のハイライトが
+  // 欠けるのを防ぐため、文字数の降順（長い順）に並べる。
   const highlightTerms = Array.from(
     new Set(
       [
@@ -45,7 +47,7 @@ export const NodeReferencePanel: React.FC<NodeReferencePanelProps> = ({
           typeof value === "string" && value.trim() !== "",
       ),
     ),
-  );
+  ).sort((a, b) => b.length - a.length);
 
   const escapeRegExp = (value: string) =>
     value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/app/_utils/kg/filter-graph-by-entity-names.test.ts
+++ b/src/app/_utils/kg/filter-graph-by-entity-names.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type {
+  GraphDocumentForFrontend,
+  NodeTypeForFrontend,
+  RelationshipTypeForFrontend,
+} from "@/app/const/types";
+import { filterGraphByEntityNames } from "./filter-graph-by-entity-names";
+
+function node(
+  id: string,
+  name: string,
+  properties: Record<string, string> = {},
+  label = "Concept",
+): NodeTypeForFrontend {
+  return { id, name, label, properties };
+}
+
+function rel(
+  id: string,
+  sourceId: string,
+  targetId: string,
+): RelationshipTypeForFrontend {
+  return { id, type: "REL", properties: {}, sourceId, targetId };
+}
+
+describe("filterGraphByEntityNames", () => {
+  const graph: GraphDocumentForFrontend = {
+    nodes: [
+      node("art", "ART PROJECT", {
+        name_ja: "アートプロジェクト",
+        name_en: "ART PROJECT",
+      }),
+      node("museum", "MUSEUM", { name_ja: "美術館" }),
+      node("city", "CITY", { name_ja: "都市" }),
+    ],
+    relationships: [rel("r1", "art", "museum")],
+  };
+
+  it("matches nodes by localized name variant found in text", () => {
+    // 本文からは日本語表記 "アートプロジェクト" が抽出される
+    const result = filterGraphByEntityNames(graph, ["アートプロジェクト"]);
+    const ids = result?.nodes.map((n) => n.id) ?? [];
+    // art 本体 + 隣接する museum が含まれる
+    expect(ids).toContain("art");
+    expect(ids).toContain("museum");
+    expect(ids).not.toContain("city");
+  });
+
+  it("matches the raw english name too (case insensitive)", () => {
+    const result = filterGraphByEntityNames(graph, ["art project"]);
+    expect(result?.nodes.map((n) => n.id)).toContain("art");
+  });
+
+  it("returns undefined for null graph", () => {
+    expect(filterGraphByEntityNames(null, ["art"])).toBeUndefined();
+  });
+});

--- a/src/app/_utils/kg/filter-graph-by-entity-names.ts
+++ b/src/app/_utils/kg/filter-graph-by-entity-names.ts
@@ -1,4 +1,8 @@
 import type { GraphDocumentForFrontend } from "@/app/const/types";
+import {
+  getNodeNameKeys,
+  normalizeNameKey,
+} from "@/app/_utils/kg/node-name-match";
 
 /**
  * エンティティ名のリストに基づいてグラフをフィルタリングする
@@ -16,9 +20,14 @@ export const filterGraphByEntityNames = (
   if (!graphDocument) return undefined;
 
   // エンティティ名に一致するノードをフィルタリング
-  const filteredNodes = graphDocument.nodes.filter((node) =>
-    entityNames.includes(node.name),
-  );
+  // node.name だけでなく name_ja / name_en も考慮し、表記言語の違いを吸収する
+  const entityNameKeys = new Set(entityNames.map(normalizeNameKey));
+  const filteredNodes = graphDocument.nodes.filter((node) => {
+    for (const key of getNodeNameKeys(node)) {
+      if (entityNameKeys.has(key)) return true;
+    }
+    return false;
+  });
 
   const filteredNodeIds = filteredNodes.map((node) => node.id);
 

--- a/src/app/_utils/kg/node-name-match.test.ts
+++ b/src/app/_utils/kg/node-name-match.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  getNodeNameCandidates,
+  getNodeNameKeys,
+  nodeMatchesName,
+  nodesShareName,
+  normalizeNameKey,
+} from "./node-name-match";
+
+describe("normalizeNameKey", () => {
+  it("applies NFKC, trim and lowercase", () => {
+    // 全角英字 → 半角、前後空白除去、小文字化
+    expect(normalizeNameKey("  ＡＲＴ Project  ")).toBe("art project");
+  });
+
+  it("treats width/case variants as equal", () => {
+    expect(normalizeNameKey("ART PROJECT")).toBe(normalizeNameKey("art project"));
+  });
+});
+
+describe("getNodeNameCandidates", () => {
+  it("collects name, name_ja and name_en, removing duplicates/empties", () => {
+    const node = {
+      name: "ART PROJECT",
+      properties: { name_ja: "アートプロジェクト", name_en: "ART PROJECT" },
+    };
+    expect(getNodeNameCandidates(node).sort()).toEqual(
+      ["ART PROJECT", "アートプロジェクト"].sort(),
+    );
+  });
+
+  it("handles missing/undefined properties", () => {
+    expect(getNodeNameCandidates({ name: "Solo" })).toEqual(["Solo"]);
+    expect(getNodeNameCandidates({ name: "Solo", properties: undefined })).toEqual(
+      ["Solo"],
+    );
+  });
+
+  it("ignores non-string and blank property values", () => {
+    const node = {
+      name: "Solo",
+      properties: { name_ja: "   ", name_en: 123 as unknown },
+    };
+    expect(getNodeNameCandidates(node)).toEqual(["Solo"]);
+  });
+});
+
+describe("getNodeNameKeys", () => {
+  it("produces normalized keys for every candidate", () => {
+    const keys = getNodeNameKeys({
+      name: "ART PROJECT",
+      properties: { name_ja: "アートプロジェクト", name_en: "art project" },
+    });
+    expect(keys.has("art project")).toBe(true);
+    expect(keys.has("アートプロジェクト")).toBe(true);
+    // 大文字/小文字違いは同一キーに畳まれる
+    expect(keys.size).toBe(2);
+  });
+});
+
+describe("nodesShareName", () => {
+  it("matches nodes across language variants (the duplication bug)", () => {
+    // 既存ノード: 生 name が英語
+    const existing = {
+      name: "ART PROJECT",
+      properties: { name_ja: "アートプロジェクト", name_en: "ART PROJECT" },
+    };
+    // 新規抽出ノード: 生 name が日本語
+    const extracted = {
+      name: "アートプロジェクト",
+      properties: { name_ja: "アートプロジェクト", name_en: "ART PROJECT" },
+    };
+    expect(nodesShareName(existing, extracted)).toBe(true);
+  });
+
+  it("matches when only one localized field overlaps", () => {
+    const a = { name: "Beuys", properties: { name_ja: "ボイス" } };
+    const b = { name: "ボイス", properties: {} };
+    expect(nodesShareName(a, b)).toBe(true);
+  });
+
+  it("returns false for genuinely different nodes", () => {
+    const a = {
+      name: "ART PROJECT",
+      properties: { name_ja: "アートプロジェクト" },
+    };
+    const b = { name: "MUSEUM", properties: { name_ja: "美術館" } };
+    expect(nodesShareName(a, b)).toBe(false);
+  });
+
+  it("falls back to raw name comparison when no localized props exist", () => {
+    expect(nodesShareName({ name: "Foo" }, { name: "foo" })).toBe(true);
+    expect(nodesShareName({ name: "Foo" }, { name: "Bar" })).toBe(false);
+  });
+});
+
+describe("nodeMatchesName", () => {
+  const node = {
+    name: "ART PROJECT",
+    properties: { name_ja: "アートプロジェクト", name_en: "ART PROJECT" },
+  };
+
+  it("matches against any name variant", () => {
+    expect(nodeMatchesName(node, "アートプロジェクト")).toBe(true);
+    expect(nodeMatchesName(node, "art project")).toBe(true);
+    expect(nodeMatchesName(node, "ART PROJECT")).toBe(true);
+  });
+
+  it("returns false for empty or non-matching names", () => {
+    expect(nodeMatchesName(node, "")).toBe(false);
+    expect(nodeMatchesName(node, "   ")).toBe(false);
+    expect(nodeMatchesName(node, "美術館")).toBe(false);
+  });
+});

--- a/src/app/_utils/kg/node-name-match.ts
+++ b/src/app/_utils/kg/node-name-match.ts
@@ -1,0 +1,57 @@
+/**
+ * ノードの同一性・名前一致判定を、抽出言語の違い（例: name="ART PROJECT" と name="アートプロジェクト"）に
+ * 影響されずに行うための共通ユーティリティ。
+ *
+ * トップレベルの `name` だけでなく `properties.name_ja` / `properties.name_en` も
+ * 名前候補として扱うことで、表示名のローカライズと生 `name` の食い違いによる
+ * 重複ノード生成・ハイライト漏れ・クリック時のノード未検出などを防ぐ。
+ */
+
+export type NodeNameLike = {
+  name: string;
+  properties?: unknown;
+};
+
+/** 同一性キー用の正規化: NFKC + trim + 小文字化（全角/半角・大文字小文字の揺れを吸収） */
+export const normalizeNameKey = (value: string): string =>
+  value.normalize("NFKC").trim().toLowerCase();
+
+/**
+ * ノードの名前候補（生の文字列）を返す。
+ * ハイライトや検索など「実際の表記でマッチさせたい」用途で使う。
+ * 重複は除去する。
+ */
+export const getNodeNameCandidates = (node: NodeNameLike): string[] => {
+  const properties = (node.properties ?? {}) as Record<string, unknown>;
+  const raw = [node.name, properties.name_ja, properties.name_en].filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim() !== "",
+  );
+  return Array.from(new Set(raw.map((value) => value.trim())));
+};
+
+/**
+ * ノードの同一性判定に使う正規化済みキー集合を返す。
+ */
+export const getNodeNameKeys = (node: NodeNameLike): Set<string> =>
+  new Set(getNodeNameCandidates(node).map(normalizeNameKey));
+
+/**
+ * 2つのノードが name / name_ja / name_en のいずれかで一致すれば同一とみなす。
+ */
+export const nodesShareName = (a: NodeNameLike, b: NodeNameLike): boolean => {
+  const keysA = getNodeNameKeys(a);
+  for (const key of getNodeNameKeys(b)) {
+    if (keysA.has(key)) return true;
+  }
+  return false;
+};
+
+/**
+ * ノードが与えられた名前文字列（生 name / name_ja / name_en のいずれか）に一致するか。
+ * クリック時のノード特定などに使う。
+ */
+export const nodeMatchesName = (node: NodeNameLike, name: string): boolean => {
+  if (!name || name.trim() === "") return false;
+  return getNodeNameKeys(node).has(normalizeNameKey(name));
+};

--- a/src/app/_utils/text/highlight-entities.test.ts
+++ b/src/app/_utils/text/highlight-entities.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { CustomNodeType } from "@/app/const/types";
+import { findEntityMatches } from "./highlight-entities";
+
+function entity(
+  id: string,
+  name: string,
+  properties: Record<string, string> = {},
+  label = "Concept",
+): CustomNodeType {
+  return { id, name, label, properties } as unknown as CustomNodeType;
+}
+
+describe("findEntityMatches", () => {
+  it("highlights the localized name even when node.name is the other language", () => {
+    // node.name は英語だが、本文は日本語 → name_ja でマッチできる
+    const entities = [
+      entity("1", "ART PROJECT", {
+        name_ja: "アートプロジェクト",
+        name_en: "ART PROJECT",
+      }),
+    ];
+    const matches = findEntityMatches(
+      "このアートプロジェクトは重要だ",
+      entities,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.entityId).toBe("1");
+    expect(matches[0]?.entityName).toBe("ART PROJECT");
+  });
+
+  it("still matches the raw name (case insensitive)", () => {
+    const entities = [
+      entity("1", "ART PROJECT", { name_ja: "アートプロジェクト" }),
+    ];
+    const matches = findEntityMatches("This art project matters", entities);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.entityId).toBe("1");
+  });
+
+  it("does not double-count overlapping candidates for the same entity", () => {
+    // name と name_en が同一表記。重複マッチを作らない
+    const entities = [
+      entity("1", "ART PROJECT", {
+        name_ja: "アートプロジェクト",
+        name_en: "ART PROJECT",
+      }),
+    ];
+    const matches = findEntityMatches("An ART PROJECT here", entities);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("returns no match when neither variant appears", () => {
+    const entities = [entity("1", "MUSEUM", { name_ja: "美術館" })];
+    expect(findEntityMatches("アートプロジェクトの話", entities)).toHaveLength(0);
+  });
+});

--- a/src/app/_utils/text/highlight-entities.ts
+++ b/src/app/_utils/text/highlight-entities.ts
@@ -1,4 +1,5 @@
 import type { CustomNodeType } from "@/app/const/types";
+import { getNodeNameCandidates } from "@/app/_utils/kg/node-name-match";
 
 const NORMALIZE_FORM: "NFC" | "NFD" = "NFC";
 
@@ -49,13 +50,22 @@ export const findEntityMatches = (
   const normalizedText = normalizeForMatch(text);
   const matches: HighlightMatch[] = [];
 
-  // 長いエンティティ名から順に処理（部分一致を防ぐため）
-  const sortedEntities = [...entities]
-    .filter((e) => e.name.length > 0)
-    .sort((a, b) => b.name.length - a.name.length);
+  // エンティティごとに name / name_ja / name_en を候補として展開し、
+  // 表記の言語違い（例: name が英語で本文が日本語）でもハイライトできるようにする。
+  const candidates = entities.flatMap((entity) =>
+    getNodeNameCandidates(entity).map((candidateName) => ({
+      entity,
+      candidateName,
+    })),
+  );
 
-  sortedEntities.forEach((entity) => {
-    const normalizedName = normalizeForMatch(entity.name);
+  // 長い名前から順に処理（部分一致を防ぐため）
+  const sortedCandidates = candidates
+    .filter((c) => c.candidateName.length > 0)
+    .sort((a, b) => b.candidateName.length - a.candidateName.length);
+
+  sortedCandidates.forEach(({ entity, candidateName }) => {
+    const normalizedName = normalizeForMatch(candidateName);
     const regex = new RegExp(escapeRegExp(normalizedName), "gi");
     let match: RegExpExecArray | null;
 

--- a/src/app/const/types.ts
+++ b/src/app/const/types.ts
@@ -139,6 +139,7 @@ export type NodeTypeForFrontend = {
   isAdditional?: boolean;
   isMergeTarget?: boolean;
   isExistingContext?: boolean;
+  isNewlyAdded?: boolean; // これから新規追加されるノード（抽出プレビュー用）
   isAddedInHistory?: boolean; // 変更履歴で追加されたノード
   isRemovedInHistory?: boolean; // 変更履歴で削除されたノード
 };
@@ -153,6 +154,7 @@ export type RelationshipTypeForFrontend = {
   documentGraphId?: string;
   isAdditional?: boolean;
   isExistingContext?: boolean;
+  isNewlyAdded?: boolean; // これから新規追加されるエッジ（抽出プレビュー用）
   isAddedInHistory?: boolean; // 変更履歴で追加されたエッジ
   isRemovedInHistory?: boolean; // 変更履歴で削除されたエッジ
 };

--- a/src/server/api/routers/kg-integration.ts
+++ b/src/server/api/routers/kg-integration.ts
@@ -5,6 +5,7 @@ import {
   formNodeDataForFrontend,
 } from "@/app/_utils/kg/frontend-properties";
 import type {
+  LocaleEnum,
   NodeTypeForFrontend,
   RelationshipTypeForFrontend,
 } from "@/app/const/types";
@@ -49,6 +50,10 @@ export const integrationProcedures = {
     .input(GetRelatedNodesInputSchema)
     .query(async ({ ctx, input }) => {
       const { nodeId, contextId, contextType } = input;
+      // 表示言語（ユーザーのpreferredLocale）に応じてノード名を name_ja / name_en から解決する
+      const preferredLocale = ctx.session?.user.preferredLocale as
+        | LocaleEnum
+        | undefined;
 
       let graphData;
 
@@ -111,7 +116,7 @@ export const integrationProcedures = {
         properties: {},
       };
       const neighborNodes = getNeighborNodes(
-        formGraphDataForFrontend(graphData),
+        formGraphDataForFrontend({ preferredLocale, ...graphData }),
         nodeId,
         "BOTH",
       );
@@ -166,6 +171,7 @@ export const integrationProcedures = {
       );
 
       return formGraphDataForFrontend({
+        preferredLocale,
         ...unifiedGraphData,
         nodes: unifiedGraphData.nodes.map((node) => ({
           documentGraphId: null,

--- a/src/server/api/routers/topic-space.ts
+++ b/src/server/api/routers/topic-space.ts
@@ -596,9 +596,15 @@ export const topicSpaceRouter = createTRPCRouter({
     }),
 
   getNodeReference: protectedProcedure
-    .input(z.object({ id: z.string(), nodeId: z.string() }))
+    .input(
+      z.object({
+        id: z.string(),
+        nodeId: z.string(),
+        // provenance: このノードの出自ドキュメントのみ / others: 出自以外のみ / all: 全件（後方互換）
+        scope: z.enum(["provenance", "others", "all"]).default("all"),
+      }),
+    )
     .query(async ({ ctx, input }) => {
-      console.log("======= getNodeReference ========", input);
       const topicSpace = await ctx.db.topicSpace.findFirst({
         where: { id: input.id },
         include: {
@@ -618,18 +624,49 @@ export const topicSpaceRouter = createTRPCRouter({
         throw new Error("Node not found");
       }
 
+      // 検索キーワード: DBの生 name に加え、ローカライズ名(name_ja/name_en)も含める。
+      // これによりドキュメントの言語に依らずヒットしやすくする。
+      const nodeProperties = (node.properties ?? {}) as Record<string, unknown>;
+      const searchTerms = Array.from(
+        new Set(
+          [node.name, nodeProperties.name_ja, nodeProperties.name_en]
+            .filter(
+              (value): value is string =>
+                typeof value === "string" && value.trim() !== "",
+            )
+            .map((value) => value.trim()),
+        ),
+      );
+
+      // scope に応じて検索対象ドキュメントを絞り込む。
+      // provenance/others の場合はこのノードの出自ドキュメントID集合を取得する。
+      let provenanceIds = new Set<string>();
+      if (input.scope !== "all") {
+        const provenanceRows =
+          await ctx.db.topicSpaceDocumentNodeProvenance.findMany({
+            where: { topicSpaceId: input.id, graphNodeId: input.nodeId },
+            select: { sourceDocumentId: true },
+          });
+        provenanceIds = new Set(
+          provenanceRows.map((row) => row.sourceDocumentId),
+        );
+      }
+
+      const targetDocuments = topicSpace.sourceDocuments.filter((doc) => {
+        if (input.scope === "provenance") return provenanceIds.has(doc.id);
+        if (input.scope === "others") return !provenanceIds.has(doc.id);
+        return true;
+      });
+
       const referenceSections: ReferenceSection[] = [];
 
-      console.log("======= node.name ========", node.name);
-
-      for (const sourceDocument of topicSpace.sourceDocuments) {
+      for (const sourceDocument of targetDocuments) {
         const relevantSections = await getTextReference(
           ctx,
           sourceDocument.id,
-          [node.name],
+          searchTerms,
           200,
         );
-        console.log("======= relevantSections ========", relevantSections);
         referenceSections.push({
           sourceDocument: sourceDocument,
           relevantSections: relevantSections.map((section) => section + "..."),
@@ -662,13 +699,34 @@ export const topicSpaceRouter = createTRPCRouter({
         throw new Error("Node not found");
       }
 
+      // 検索キーワード: DBの生 name に加え、ローカライズ名(name_ja/name_en)も含める。
+      // これによりドキュメントの言語に依らずヒットしやすくする（例: name が英語でも日本語文書を検索できる）。
+      const nodeProperties = (node.properties ?? {}) as Record<string, unknown>;
+      const searchTerms = Array.from(
+        new Set(
+          [node.name, nodeProperties.name_ja, nodeProperties.name_en]
+            .filter(
+              (value): value is string =>
+                typeof value === "string" && value.trim() !== "",
+            )
+            .map((value) => value.trim()),
+        ),
+      );
+
+      // 解説文は日本語で生成するため、プロンプトでは日本語名(name_ja)を優先して用いる。
+      const promptNodeName =
+        typeof nodeProperties.name_ja === "string" &&
+        nodeProperties.name_ja.trim() !== ""
+          ? nodeProperties.name_ja.trim()
+          : node.name;
+
       let referenceText = "";
 
       for (const sourceDocument of topicSpace.sourceDocuments) {
         const relevantSections = await getTextReference(
           ctx,
           sourceDocument.id,
-          [node.name],
+          searchTerms,
           800,
         );
         referenceText += relevantSections.join("\n---\n");
@@ -694,13 +752,13 @@ export const topicSpaceRouter = createTRPCRouter({
               },
               {
                 role: "user",
-                content: `ノード名: ${node.name}
+                content: `ノード名: ${promptNodeName}
 ノードラベル: ${node.label}
 
 関連文書:
 ${referenceText}
 
-上記の文書を基に、「${node.name}」についての解説文を作成してください。`,
+上記の文書を基に、「${promptNodeName}」についての解説文を作成してください。`,
               },
             ],
             max_tokens: 500,

--- a/src/server/domain/kg/data-disambiguation.test.ts
+++ b/src/server/domain/kg/data-disambiguation.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import type { GraphNode, GraphRelationship } from "@prisma/client";
+import { dataDisambiguation, fuseGraphs } from "./data-disambiguation";
+
+function node(
+  id: string,
+  name: string,
+  label: string,
+  properties: Record<string, string> = {},
+): GraphNode {
+  return {
+    id,
+    name,
+    label,
+    properties,
+    documentGraphId: null,
+    topicSpaceId: null,
+    createdAt: null,
+    updatedAt: null,
+    deletedAt: null,
+  } as unknown as GraphNode;
+}
+
+function rel(
+  id: string,
+  type: string,
+  fromNodeId: string,
+  toNodeId: string,
+): GraphRelationship {
+  return {
+    id,
+    type,
+    properties: {},
+    fromNodeId,
+    toNodeId,
+    documentGraphId: null,
+    topicSpaceId: null,
+    createdAt: null,
+    updatedAt: null,
+    deletedAt: null,
+  } as unknown as GraphRelationship;
+}
+
+describe("fuseGraphs (integrate scenario)", () => {
+  it("does not duplicate a node when languages of the raw name differ", async () => {
+    // 既存(topicSpace)ノード: 生 name が英語
+    const sourceGraph = {
+      nodes: [
+        node("existing-art", "ART PROJECT", "Concept", {
+          name_ja: "アートプロジェクト",
+          name_en: "ART PROJECT",
+        }),
+      ],
+      relationships: [],
+    };
+
+    // 新規抽出(統合ペイロード): 同じ概念だが生 name は日本語 + 新規ノード + エッジ
+    const targetGraph = {
+      nodes: [
+        node("incoming-art", "アートプロジェクト", "Concept", {
+          name_ja: "アートプロジェクト",
+          name_en: "ART PROJECT",
+        }),
+        node("incoming-exhibition", "展覧会", "Event", {
+          name_ja: "展覧会",
+          name_en: "Exhibition",
+        }),
+      ],
+      relationships: [rel("r1", "HAS", "incoming-art", "incoming-exhibition")],
+    };
+
+    const result = await fuseGraphs({
+      sourceGraph,
+      targetGraph,
+      labelCheck: false,
+    });
+
+    // アートプロジェクトが重複せず、既存 + 新規(展覧会) の 2 ノードになる
+    expect(result.nodes).toHaveLength(2);
+    const names = result.nodes.map((n) => n.name);
+    expect(names).toContain("ART PROJECT"); // 既存ノードはそのまま残る
+    expect(names).toContain("展覧会");
+    expect(names).not.toContain("アートプロジェクト"); // 日本語生 name の重複は作られない
+
+    // 抽出側 アートプロジェクト は既存ノード id にマップされる
+    const record = result.nodeIdRecords.find(
+      (r) => r.prevId === "incoming-art",
+    );
+    expect(record?.newId).toBe("existing-art");
+
+    // エッジは既存ノード → 新規(展覧会) を指す
+    expect(result.relationships).toHaveLength(1);
+    const exhibitionNode = result.nodes.find((n) => n.name === "展覧会");
+    expect(result.relationships[0]?.fromNodeId).toBe("existing-art");
+    expect(result.relationships[0]?.toNodeId).toBe(exhibitionNode?.id);
+  });
+
+  it("still merges by name when labelCheck is false regardless of label", async () => {
+    const sourceGraph = {
+      nodes: [node("s1", "ART PROJECT", "Concept", { name_ja: "アートプロジェクト" })],
+      relationships: [],
+    };
+    const targetGraph = {
+      nodes: [node("t1", "アートプロジェクト", "Activity", { name_en: "ART PROJECT" })],
+      relationships: [],
+    };
+
+    const result = await fuseGraphs({
+      sourceGraph,
+      targetGraph,
+      labelCheck: false,
+    });
+    expect(result.nodes).toHaveLength(1);
+  });
+
+  it("keeps nodes separate when labelCheck is true and labels differ", async () => {
+    const sourceGraph = {
+      nodes: [node("s1", "ART PROJECT", "Concept", { name_ja: "アートプロジェクト" })],
+      relationships: [],
+    };
+    const targetGraph = {
+      nodes: [node("t1", "アートプロジェクト", "Activity", { name_en: "ART PROJECT" })],
+      relationships: [],
+    };
+
+    const result = await fuseGraphs({
+      sourceGraph,
+      targetGraph,
+      labelCheck: true,
+    });
+    expect(result.nodes).toHaveLength(2);
+  });
+
+  it("adds genuinely new nodes", async () => {
+    const sourceGraph = {
+      nodes: [node("s1", "ART PROJECT", "Concept")],
+      relationships: [],
+    };
+    const targetGraph = {
+      nodes: [node("t1", "MUSEUM", "Place", { name_ja: "美術館" })],
+      relationships: [],
+    };
+
+    const result = await fuseGraphs({
+      sourceGraph,
+      targetGraph,
+      labelCheck: false,
+    });
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map((n) => n.name)).toEqual(
+      expect.arrayContaining(["ART PROJECT", "MUSEUM"]),
+    );
+  });
+});
+
+describe("dataDisambiguation (simpleMerge)", () => {
+  it("dedupes language variants inside a single graph", () => {
+    const graph = {
+      nodes: [
+        node("a", "ART PROJECT", "Concept", {
+          name_ja: "アートプロジェクト",
+          name_en: "ART PROJECT",
+        }),
+        node("b", "アートプロジェクト", "Concept", {
+          name_ja: "アートプロジェクト",
+          name_en: "ART PROJECT",
+        }),
+        node("c", "MUSEUM", "Place"),
+      ],
+      relationships: [rel("r1", "AT", "b", "c")],
+    };
+
+    const result = dataDisambiguation(graph);
+    expect(result.nodes).toHaveLength(2);
+    // 重複していた b は a に統合され、エッジの端点が a に付け替わる
+    const rel1 = result.relationships[0];
+    expect(rel1?.fromNodeId).toBe("a");
+    expect(rel1?.toNodeId).toBe("c");
+  });
+});

--- a/src/server/domain/kg/data-disambiguation.ts
+++ b/src/server/domain/kg/data-disambiguation.ts
@@ -1,4 +1,5 @@
 import { createId } from "@/app/_utils/cuid/cuid";
+import { nodesShareName } from "@/app/_utils/kg/node-name-match";
 import type { NodeTypeForFrontend } from "@/app/const/types";
 import type { GraphNode, GraphRelationship } from "@prisma/client";
 
@@ -78,7 +79,7 @@ const mergerGraphsWithDuplicatedNodeName = (p: {
   const duplicatedTargetNodes = targetGraph.nodes.filter((sourceNode) => {
     return sourceGraph.nodes.some((targetNode) => {
       return (
-        targetNode.name === sourceNode.name &&
+        nodesShareName(targetNode, sourceNode) &&
         (labelCheck ? targetNode.label === sourceNode.label : true)
       );
     });
@@ -86,7 +87,7 @@ const mergerGraphsWithDuplicatedNodeName = (p: {
   const additionalNodes = targetGraph.nodes.filter((sourceNode) => {
     return !sourceGraph.nodes.some((targetNode) => {
       return (
-        targetNode.name === sourceNode.name &&
+        nodesShareName(targetNode, sourceNode) &&
         (labelCheck ? targetNode.label === sourceNode.label : true)
       );
     });
@@ -100,7 +101,8 @@ const mergerGraphsWithDuplicatedNodeName = (p: {
     const prevId = dNode.id;
     const newId = newNodes.find((nn) => {
       return (
-        nn.name === dNode.name && (labelCheck ? nn.label === dNode.label : true)
+        nodesShareName(nn, dNode) &&
+        (labelCheck ? nn.label === dNode.label : true)
       );
     })?.id;
     if (newId) {
@@ -154,7 +156,7 @@ const simpleMerge = (graph: {
 
   nodes.forEach((node) => {
     const existingNode = uniqueNodes.find(
-      (n) => n.name === node.name && n.label === node.label,
+      (n) => nodesShareName(n, node) && n.label === node.label,
     );
 
     if (existingNode) {
@@ -205,7 +207,9 @@ export const attachGraphProperties = (
 ) => {
   const newNodesWithProperties = newGraph.nodes.map((nn) => {
     const matchedPrevNode = prevGraph.nodes.find((pn) => {
-      return pn.name === nn.name && (labelCheck ? pn.label === nn.label : true);
+      return (
+        nodesShareName(pn, nn) && (labelCheck ? pn.label === nn.label : true)
+      );
     });
     if (!!matchedPrevNode && !!matchedPrevNode.properties) {
       return { ...nn, properties: matchedPrevNode.properties };

--- a/src/server/repositories/topic-space-document-provenance.repository.ts
+++ b/src/server/repositories/topic-space-document-provenance.repository.ts
@@ -1,4 +1,5 @@
 import type { GraphEditChange, Prisma, PrismaClient } from "@prisma/client";
+import { nodesShareName } from "@/app/_utils/kg/node-name-match";
 import type { DraftGraphData } from "@/server/services/graph-edit-proposal/draft.service";
 import { reconstructDraftGraphData } from "@/server/services/graph-edit-proposal/draft.service";
 
@@ -76,7 +77,7 @@ export function extractNodeMergePairsFromProposal(
     const canonical = draftGraphData.nodes.find(
       (node) =>
         node.id !== removed.id &&
-        node.name === removed.name &&
+        nodesShareName(node, removed) &&
         node.label === removed.label,
     );
     if (!canonical) {

--- a/src/server/services/kg/topic-space-graph-fusion.service.ts
+++ b/src/server/services/kg/topic-space-graph-fusion.service.ts
@@ -2,6 +2,7 @@ import {
   attachGraphProperties,
   fuseGraphs,
 } from "@/server/domain/kg/data-disambiguation";
+import { nodesShareName } from "@/app/_utils/kg/node-name-match";
 import type { PrismaClient } from "@prisma/client";
 import type {
   GraphNode,
@@ -169,12 +170,12 @@ export async function detachTopicSpaceGraphData(
     return (
       documentGraph.graphNodes.some(
         (documentGraphNode) =>
-          documentGraphNode.name === topicSpaceNode.name &&
+          nodesShareName(documentGraphNode, topicSpaceNode) &&
           documentGraphNode.label === topicSpaceNode.label,
       ) &&
       !otherDocumentGraphNodes.some(
         (otherDocumentGraphNode) =>
-          otherDocumentGraphNode.name === topicSpaceNode.name &&
+          nodesShareName(otherDocumentGraphNode, topicSpaceNode) &&
           otherDocumentGraphNode.label === topicSpaceNode.label,
       )
     );


### PR DESCRIPTION
## Summary

- ノードの生 `name` が抽出言語によって異なる（例: 既存ノード="ART PROJECT" / 新規抽出="アートプロジェクト"）ことで、統合時に**同一概念のノードが重複生成**される不具合を修正しました。
- ノード名一致に依存していた各所を、`name` / `properties.name_ja` / `properties.name_en` を正規化(NFKC + trim + 小文字化)して判定する共通ユーティリティ `node-name-match.ts` に統一しました。
- あわせて、これまでの一連のグラフ編集UX改善（抽出プレビューの直感的編集・ライブシミュレーション、反映ボタンの永続化と隣接グラフ更新、新規ノード/エッジの緑色表示、controlled/uncontrolled 警告解消、引用検索の多言語対応など）を含みます。

## 主な変更

### 同一性判定の共通化（重複・誤マッチ防止）
- `src/app/_utils/kg/node-name-match.ts`（新規）: `getNodeNameCandidates` / `getNodeNameKeys` / `nodesShareName` / `nodeMatchesName`
- `data-disambiguation.ts`: `fuseGraphs` / `simpleMerge` / `attachGraphProperties`
- `topic-space-graph-fusion.service.ts`: デタッチ時の削除ノード判定
- `topic-space-document-provenance.repository.ts`: マージペア抽出の canonical 特定
- `highlight-entities.ts` / `filter-graph-by-entity-names.ts`: 本文ハイライト・グラフ絞り込み
- `public-article-viewer.tsx` / `curators-writing-workspace.tsx` / `radial-tree.tsx`: クリック・選択判定
- `additional-graph-extraction-modal.tsx`: フロント側の既存エンティティ統合判定

### グラフ編集UX
- 追加グラフの反映を TopicSpace へ直接統合し、隣接グラフを再取得
- 抽出プレビューの直感的編集(DnD)・ライブシミュレーション・新規ノード/エッジの緑色表示・DnD時のプロパティ編集ポップアップ
- controlled/uncontrolled input 警告の解消
- `getNodeReference` / `generateNodeDescription` の多言語検索対応

## Test plan

- [x] `npm run test:unit`（新規テスト24件パス: node-name-match / data-disambiguation / highlight-entities / filter-graph-by-entity-names）
- [x] `tsc --noEmit` 型チェック通過
- [x] ローカル build 通過（確認済み）
- [ ] 既存の重複ノードは手動マージで解消（今後の統合では言語違いによる重複は発生しない）


Made with [Cursor](https://cursor.com)