### PR TITLE
UI言語に応じたノード解説文生成のローカライズと生成モデルの更新

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -603,7 +603,7 @@
     "mappingFailed": "Mapping failed",
     "retry": "Retry",
     "noAnnotationsYet": "No annotations yet",
-    "generateFromDocument": "Generate annotations from document",
+    "generateFromDocument": "Generate annotations from documents",
     "replyCount": "{count} replies",
     "viewAllReplies": "View all replies (+ {count} more)",
     "graphExtraction": "Extract graph",

--- a/src/server/api/routers/topic-space.ts
+++ b/src/server/api/routers/topic-space.ts
@@ -48,6 +48,12 @@ import { storageUtils } from "@/app/_utils/supabase/supabase";
 import { TRPCError } from "@trpc/server";
 import { buildDriveFolderUrl } from "@/server/lib/google-drive/urls";
 import { hasUserGoogleDriveConnection } from "@/server/lib/google-drive/user-oauth";
+import {
+  getNodeDescriptionSystemPrompt,
+  getNodeDescriptionUserPrompt,
+  getNodeDescriptionGenerationFailedMessage,
+  getNodeDescriptionNoReferenceMessage,
+} from "@/server/lib/i18n/prompts/node-description";
 import OpenAI from "openai";
 
 const TopicSpaceCreateSchema = z.object({
@@ -713,11 +719,14 @@ export const topicSpaceRouter = createTRPCRouter({
         ),
       );
 
-      // 解説文は日本語で生成するため、プロンプトでは日本語名(name_ja)を優先して用いる。
+      // UI言語に合わせて解説文を生成する。プロンプトのノード名も
+      // 表示言語に対応するローカライズ名(en → name_en / ja → name_ja)を優先する。
+      const locale = ctx.locale;
+      const localizedNameKey = locale === "en" ? "name_en" : "name_ja";
+      const localizedName = nodeProperties[localizedNameKey];
       const promptNodeName =
-        typeof nodeProperties.name_ja === "string" &&
-        nodeProperties.name_ja.trim() !== ""
-          ? nodeProperties.name_ja.trim()
+        typeof localizedName === "string" && localizedName.trim() !== ""
+          ? localizedName.trim()
           : node.name;
 
       let referenceText = "";
@@ -737,32 +746,25 @@ export const topicSpaceRouter = createTRPCRouter({
         try {
           const openai = new OpenAI();
           const stream = await openai.chat.completions.create({
-            model: "gpt-4o-mini",
+            model: "gpt-5.4-mini",
             messages: [
               {
                 role: "system",
-                content: `あなたは専門的な知識を分かりやすく解説するエキスパートです。与えられた文書から、指定されたノード（概念）について、簡潔で分かりやすい解説文を作成してください。
-
-解説文の要件：
-- 200-300文字程度の簡潔な説明
-- 専門用語は適切に説明する
-- 文書の内容を基にした正確な情報
-- 読み手が理解しやすい構成
-- 日本語で記述`,
+                content: getNodeDescriptionSystemPrompt(locale),
               },
               {
                 role: "user",
-                content: `ノード名: ${promptNodeName}
-ノードラベル: ${node.label}
-
-関連文書:
-${referenceText}
-
-上記の文書を基に、「${promptNodeName}」についての解説文を作成してください。`,
+                content: getNodeDescriptionUserPrompt(locale, {
+                  nodeName: promptNodeName,
+                  nodeLabel: node.label,
+                  referenceText,
+                }),
               },
             ],
-            max_tokens: 500,
-            temperature: 0.7,
+            // gpt-5 系は reasoning モデルのため max_completion_tokens を使用し、
+            // temperature は既定値(1)のみ許容されるため指定しない。
+            max_completion_tokens: 1500,
+            reasoning_effort: "low",
             stream: true,
           });
 
@@ -788,14 +790,14 @@ ${referenceText}
           console.error("OpenAI API error:", error);
           yield {
             node: node,
-            description: "解説文の生成に失敗しました。",
+            description: getNodeDescriptionGenerationFailedMessage(locale),
             isComplete: true,
           };
         }
       } else {
         yield {
           node: node,
-          description: "関連する文書が見つかりませんでした。",
+          description: getNodeDescriptionNoReferenceMessage(locale),
           isComplete: true,
         };
       }

--- a/src/server/lib/i18n/prompts/node-description.ts
+++ b/src/server/lib/i18n/prompts/node-description.ts
@@ -1,0 +1,62 @@
+import type { Locale } from "i18n/routing";
+
+export function getNodeDescriptionSystemPrompt(locale: Locale): string {
+  if (locale === "en") {
+    return `You are an expert who explains specialized knowledge in an accessible way. From the given documents, write a concise and easy-to-understand description of the specified node (concept).
+
+Requirements for the description:
+- A concise explanation of roughly 120-180 words
+- Explain technical terms appropriately
+- Accurate information grounded in the documents
+- A structure that is easy for the reader to understand
+- Write in English`;
+  }
+
+  return `あなたは専門的な知識を分かりやすく解説するエキスパートです。与えられた文書から、指定されたノード（概念）について、簡潔で分かりやすい解説文を作成してください。
+
+解説文の要件：
+- 200-300文字程度の簡潔な説明
+- 専門用語は適切に説明する
+- 文書の内容を基にした正確な情報
+- 読み手が理解しやすい構成
+- 日本語で記述`;
+}
+
+export function getNodeDescriptionUserPrompt(
+  locale: Locale,
+  params: { nodeName: string; nodeLabel: string; referenceText: string },
+): string {
+  const { nodeName, nodeLabel, referenceText } = params;
+
+  if (locale === "en") {
+    return `Node name: ${nodeName}
+Node label: ${nodeLabel}
+
+Related documents:
+${referenceText}
+
+Based on the documents above, write a description of "${nodeName}".`;
+  }
+
+  return `ノード名: ${nodeName}
+ノードラベル: ${nodeLabel}
+
+関連文書:
+${referenceText}
+
+上記の文書を基に、「${nodeName}」についての解説文を作成してください。`;
+}
+
+export function getNodeDescriptionGenerationFailedMessage(
+  locale: Locale,
+): string {
+  return locale === "en"
+    ? "Failed to generate the description."
+    : "解説文の生成に失敗しました。";
+}
+
+export function getNodeDescriptionNoReferenceMessage(locale: Locale): string {
+  return locale === "en"
+    ? "No related documents were found."
+    : "関連する文書が見つかりませんでした。";
+}


### PR DESCRIPTION
## 概要

「ドキュメントから注釈を生成（Generate annotations from documents）」機能で、ノード解説文の生成を UI 言語に追従させ、生成モデルを GPT-5 系へ更新しました。

- **UI言語による生成言語の切り替え**: これまでプロンプトが日本語固定だったため、UI言語が英語でも解説文が日本語で出力されていました。tRPC context の `ctx.locale` を利用し、system/user プロンプトを日本語/英語で出し分けます。
- **ローカライズ名の優先**: 英語ロケール時は `name_en`、日本語ロケール時は `name_ja` を優先してプロンプトのノード名に使用します（従来は常に `name_ja` 固定）。
- **i18n プロンプトヘルパーの追加**: 既存の `src/server/lib/i18n/prompts/` の慣例に沿って `node-description.ts` を新設し、system/user プロンプトと失敗・該当なしメッセージを集約。
- **生成モデルの更新**: `gpt-4o-mini` → `gpt-5.4-mini`（コスパ重視、`iterative-core` の PHASE1_MODEL と統一）。reasoning モデルのため `max_tokens`→`max_completion_tokens`、`temperature` 削除、`reasoning_effort: "low"` を追加。
- **表記修正**: バックエンドはトピックスペースの全 `sourceDocuments` を横断参照するため、英語ラベルを `Generate annotations from document` → `documents`（複数形）に修正。

## 変更ファイル

- `src/server/api/routers/topic-space.ts` — `generateNodeDescriptionFromDocument` のロケール対応・モデル更新
- `src/server/lib/i18n/prompts/node-description.ts` — 新規プロンプトヘルパー
- `messages/en.json` — 英語ラベルの複数形修正

## テスト計画

- [ ] UI言語=日本語でノード解説文が日本語生成されること
- [ ] UI言語=英語でノード解説文が英語生成されること
- [ ] 関連文書が無い場合のフォールバックメッセージがロケールに応じて表示されること
- [ ] ストリーミング表示が従来通り動作すること

Made with [Cursor](https://cursor.com)